### PR TITLE
fix(playwright-browser): use Alpine base image and apk instead of apt-get

### DIFF
--- a/playwright-browser/CHANGELOG.md
+++ b/playwright-browser/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.12] - 2026-03-03
+
+### Fixed
+- Replace apt-get with apk for Alpine compatibility
+- Switch base image from mcr.microsoft.com/playwright to HA Alpine base
+- Install Chromium from Alpine packages (chromium, jq, curl, nginx)
+
 ## [0.1.11] - 2026-02-23
 
 ### Added

--- a/playwright-browser/Dockerfile
+++ b/playwright-browser/Dockerfile
@@ -11,11 +11,12 @@ LABEL org.opencontainers.image.description="Headless Chromium with CDP endpoint 
 LABEL org.opencontainers.image.source="https://github.com/robsonfelix/robsonfelix-hass-addons"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# jq is already available in the Playwright image (Ubuntu-based)
-# Just ensure it's installed
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq curl nginx && \
-    rm -rf /var/lib/apt/lists/*
+# Install Chromium and dependencies from Alpine packages
+RUN apk add --no-cache \
+    chromium \
+    jq \
+    curl \
+    nginx
 
 # Create data directory
 RUN mkdir -p /data

--- a/playwright-browser/build.yaml
+++ b/playwright-browser/build.yaml
@@ -1,3 +1,3 @@
 build_from:
-  amd64: mcr.microsoft.com/playwright:v1.57.0-noble
-  aarch64: mcr.microsoft.com/playwright:v1.57.0-noble
+  amd64: ghcr.io/home-assistant/amd64-base:latest
+  aarch64: ghcr.io/home-assistant/aarch64-base:latest

--- a/playwright-browser/config.yaml
+++ b/playwright-browser/config.yaml
@@ -1,6 +1,6 @@
 name: Playwright Browser
 description: Headless Chromium browser with CDP endpoint for browser automation
-version: "0.1.11"
+version: "0.1.12"
 slug: playwright-browser
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:


### PR DESCRIPTION
## Summary

- Switch base image from `mcr.microsoft.com/playwright:v1.57.0-noble` (Ubuntu) to HA Alpine base images (`ghcr.io/home-assistant/amd64-base` / `aarch64-base`)
- Replace `apt-get` with `apk add --no-cache` and install `chromium` from Alpine packages
- Bump version to `0.1.12`

## Problem

On aarch64, the HA builder cannot resolve the Microsoft Playwright MCR image and falls back to an Alpine-based HA image. Since the Dockerfile used `apt-get`, the build fails with `apt-get: not found`.

This means the add-on cannot be updated through Home Assistant at all on aarch64 — the build fails immediately, leaving users stuck on the previous version.

## Solution

Use the standard HA Alpine base images, consistent with other add-ons in this repo. Alpine's `chromium` package installs to `/usr/bin/chromium-browser`, which `run.sh` already handles via its fallback logic. No changes to `run.sh` were needed.