### PR TITLE
fix(playwright-browser): Hardcode base image to bypass HA Supervisor

### DIFF
--- a/playwright-browser/CHANGELOG.md
+++ b/playwright-browser/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.12] - 2026-03-22
+
+### Fixed
+- Hardcode Playwright base image in Dockerfile to bypass HA Supervisor regex validation
+- HA Supervisor requires registry/org/image format but MCR uses registry/image (mcr.microsoft.com/playwright)
+- Use dummy base images in build.yaml to pass validation, actual image set directly in Dockerfile
+
 ## [0.1.11] - 2026-02-23
 
 ### Added

--- a/playwright-browser/Dockerfile
+++ b/playwright-browser/Dockerfile
@@ -1,5 +1,7 @@
+# Hardcode base image: HA Supervisor regex rejects mcr.microsoft.com/playwright
+# (requires registry/org/image format, but MCR uses registry/image)
+FROM mcr.microsoft.com/playwright:v1.57.0-noble
 ARG BUILD_FROM
-FROM ${BUILD_FROM}
 
 # Labels
 LABEL maintainer="Robson Felix"

--- a/playwright-browser/build.yaml
+++ b/playwright-browser/build.yaml
@@ -1,3 +1,3 @@
 build_from:
-  amd64: mcr.microsoft.com/playwright:v1.57.0-noble
-  aarch64: mcr.microsoft.com/playwright:v1.57.0-noble
+  amd64: ghcr.io/home-assistant/amd64-base:latest
+  aarch64: ghcr.io/home-assistant/aarch64-base:latest

--- a/playwright-browser/config.yaml
+++ b/playwright-browser/config.yaml
@@ -1,6 +1,6 @@
 name: Playwright Browser
 description: Headless Chromium browser with CDP endpoint for browser automation
-version: "0.1.11"
+version: "0.1.12"
 slug: playwright-browser
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:


### PR DESCRIPTION
regex validation

HA Supervisor requires registry/org/image:tag format (3 path segments) but MCR publishes Playwright as mcr.microsoft.com/playwright:tag (2 segments), causing build.yaml parsing to fail. Hardcode the FROM directly in the Dockerfile and use dummy HA base images in build.yaml to pass validation.