### PR TITLE
Fix playwright-browser build: apt-get not found on Alpine fallback

### DIFF
--- a/playwright-browser/Dockerfile
+++ b/playwright-browser/Dockerfile
@@ -1,5 +1,9 @@
-ARG BUILD_FROM
-FROM ${BUILD_FROM}
+# Build directly on the official Playwright image (Ubuntu Noble).
+# It ships Chromium in /ms-playwright/ (required by run.sh) and has apt-get.
+# NOTE: hardcoded instead of using BUILD_FROM/build.yaml because the HA
+# Supervisor's build_from regex rejects single-segment image paths like
+# "mcr.microsoft.com/playwright", silently falling back to the Alpine base.
+FROM mcr.microsoft.com/playwright:v1.57.0-noble
 
 # Labels
 LABEL maintainer="Robson Felix"

--- a/playwright-browser/build.yaml
+++ b/playwright-browser/build.yaml
@@ -1,3 +1,0 @@
-build_from:
-  amd64: mcr.microsoft.com/playwright:v1.57.0-noble
-  aarch64: mcr.microsoft.com/playwright:v1.57.0-noble

--- a/playwright-browser/config.yaml
+++ b/playwright-browser/config.yaml
@@ -1,6 +1,6 @@
 name: Playwright Browser
 description: Headless Chromium browser with CDP endpoint for browser automation
-version: "0.1.11"
+version: "0.1.12"
 slug: playwright-browser
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:


### PR DESCRIPTION
## Problem

Installing the **playwright-browser** add-on fails at build time with:

```
#6 0.208 /bin/ash: apt-get: not found
ERROR: process "/bin/ash -o pipefail -c apt-get update && ..." did not complete successfully: exit code: 127
```

## Root cause

The Dockerfile relies on `ARG BUILD_FROM` / `FROM ${BUILD_FROM}`, with the base image set in `build.yaml`:

```yaml
build_from:
  amd64: mcr.microsoft.com/playwright:v1.57.0-noble
  aarch64: mcr.microsoft.com/playwright:v1.57.0-noble
```

But the Supervisor rejects this `build.yaml` and falls back to the default Alpine base:

```
Error parsing ... build config (does not match regular expression
^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)(:[\.\-\w{}]+)?$
for dictionary value @ data['build_from']['amd64']), using defaults
```

The regex requires a two-segment image path (`registry/namespace/name`), but the official Playwright image is a single-segment path (`mcr.microsoft.com/playwright`). So `build.yaml` is discarded, `BUILD_FROM` defaults to `ghcr.io/home-assistant/base:latest` (Alpine), and `apt-get` does not exist there -> build fails.

## Fix

- Hardcode `FROM mcr.microsoft.com/playwright:v1.57.0-noble` directly in the Dockerfile. This image is Ubuntu Noble (has `apt-get`) **and** ships Chromium under `/ms-playwright/`, which `run.sh` already expects.
- Remove the deprecated, regex-incompatible `build.yaml`.
- Bump version to `0.1.12`.

## Testing

Builds and installs successfully on HA OS (amd64) as a custom repository. The CDP endpoint comes up on the configured port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)