### PR TITLE
feat(claudecode): Add remote control options (v1.2.64)

### DIFF
--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.64] - 2026-06-28
+
+### Added
+- New `enable_remote_control` option to automatically start Claude Code with Remote Control enabled for every session, allowing the session to be viewed and steered from claude.ai/code or the Claude mobile app
+- New `remote_control_session_prefix` option to set the prefix for auto-generated Remote Control session names (via `CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX`), defaults to "HomeAssistant"
+
 ## [1.2.63] - 2026-02-23
 
 ### Fixed

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -230,6 +230,8 @@ CMD ["/bin/bash", "-c", "\
     fi; \
   fi && \
   AUTO_UPDATE=$(jq -r '.auto_update_claude // true' /data/options.json) && \
+  REMOTE_CONTROL=$(jq -r '.enable_remote_control // false' /data/options.json) && \
+  RC_SESSION_PREFIX=$(jq -r '.remote_control_session_prefix // \"HomeAssistant\"' /data/options.json) && \
   if [ \"$AUTO_UPDATE\" = \"true\" ]; then \
     echo '[INFO] Checking for Claude Code updates...' && \
     npm update -g @anthropic-ai/claude-code 2>/dev/null || echo '[WARN] Update check failed, continuing...'; \
@@ -253,6 +255,15 @@ CMD ["/bin/bash", "-c", "\
   else \
     echo '[INFO] Playwright MCP disabled'; \
   fi && \
+  SETTINGS_FILE=/root/.claude/settings.json && \
+  if [ ! -f \"$SETTINGS_FILE\" ]; then echo '{}' > \"$SETTINGS_FILE\"; fi && \
+  if [ \"$REMOTE_CONTROL\" = \"true\" ]; then \
+    jq '.remoteControlAtStartup = true' \"$SETTINGS_FILE\" > /tmp/settings.tmp && mv /tmp/settings.tmp \"$SETTINGS_FILE\" && \
+    echo '[INFO] Remote Control enabled - Claude Code will auto-start with remote control'; \
+  else \
+    jq 'del(.remoteControlAtStartup)' \"$SETTINGS_FILE\" > /tmp/settings.tmp && mv /tmp/settings.tmp \"$SETTINGS_FILE\"; \
+    echo '[INFO] Remote Control auto-start disabled'; \
+  fi && \
   if [ \"$THEME\" = \"dark\" ]; then \
     COLORS='background=#1e1e2e,foreground=#cdd6f4,cursor=#f5e0dc'; \
   else \
@@ -263,6 +274,7 @@ CMD ["/bin/bash", "-c", "\
   else \
     SHELL_CMD='bash --login'; \
   fi && \
+  if [ \"$REMOTE_CONTROL\" = \"true\" ]; then export CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX=\"$RC_SESSION_PREFIX\"; fi && \
   cd /homeassistant && \
   exec ttyd --port 7681 --writable --ping-interval 30 --max-clients 5 \
     -t fontSize=$FONT_SIZE \

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.63"
+version: "1.2.64"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:
@@ -40,6 +40,8 @@ options:
   working_directory: /homeassistant
   session_persistence: true
   auto_update_claude: true
+  enable_remote_control: false
+  remote_control_session_prefix: HomeAssistant
 schema:
   enable_mcp: bool
   enable_playwright_mcp: bool
@@ -49,5 +51,7 @@ schema:
   working_directory: str
   session_persistence: bool
   auto_update_claude: bool
+  enable_remote_control: bool
+  remote_control_session_prefix: str
 environment:
   TERM: xterm-256color

--- a/claudecode/translations/en.yaml
+++ b/claudecode/translations/en.yaml
@@ -42,6 +42,19 @@ configuration:
     description: >-
       Automatically check for and install Claude Code updates on add-on startup.
       Keeps Claude Code current without requiring add-on version bumps.
+  enable_remote_control:
+    name: Enable Remote Control
+    description: >-
+      Automatically start Claude Code with Remote Control enabled for every session.
+      Allows you to view and steer your local Claude Code session from claude.ai/code
+      or the Claude mobile app. Requires a claude.ai Pro, Max, Team, or Enterprise
+      subscription (API keys are not supported).
+  remote_control_session_prefix:
+    name: Remote Control Session Name Prefix
+    description: >-
+      Prefix for auto-generated Remote Control session names visible in claude.ai/code
+      and the Claude mobile app. Defaults to "HomeAssistant", producing names like
+      "HomeAssistant-graceful-unicorn". Only applies when Enable Remote Control is on.
 
 network:
   7681/tcp: Web Terminal (ttyd)

--- a/claudecode/translations/es.yaml
+++ b/claudecode/translations/es.yaml
@@ -44,6 +44,19 @@ configuration:
     description: >-
       Verifica e instala automáticamente actualizaciones de Claude Code al iniciar el add-on.
       Mantiene Claude Code actualizado sin necesidad de actualizar la versión del add-on.
+  enable_remote_control:
+    name: Habilitar Control Remoto
+    description: >-
+      Inicia automáticamente Claude Code con Control Remoto habilitado en cada sesión.
+      Permite ver y controlar tu sesión local de Claude Code desde claude.ai/code
+      o la aplicación móvil de Claude. Requiere suscripción claude.ai Pro, Max, Team o
+      Enterprise (las claves de API no son compatibles).
+  remote_control_session_prefix:
+    name: Prefijo del Nombre de Sesión de Control Remoto
+    description: >-
+      Prefijo para los nombres de sesión de Control Remoto generados automáticamente,
+      visible en claude.ai/code y la aplicación móvil de Claude. El valor predeterminado
+      es "HomeAssistant", generando nombres como "HomeAssistant-graceful-unicorn". Solo aplica cuando el Control Remoto está habilitado.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/claudecode/translations/pt-BR.yaml
+++ b/claudecode/translations/pt-BR.yaml
@@ -44,6 +44,19 @@ configuration:
     description: >-
       Verifica e instala automaticamente atualizações do Claude Code ao iniciar o add-on.
       Mantém o Claude Code atualizado sem precisar atualizar a versão do add-on.
+  enable_remote_control:
+    name: Habilitar Controle Remoto
+    description: >-
+      Inicia automaticamente o Claude Code com Controle Remoto habilitado em cada sessão.
+      Permite visualizar e controlar sua sessão local do Claude Code pelo claude.ai/code
+      ou pelo aplicativo móvel do Claude. Requer assinatura claude.ai Pro, Max, Team ou
+      Enterprise (chaves de API não são suportadas).
+  remote_control_session_prefix:
+    name: Prefixo do Nome da Sessão de Controle Remoto
+    description: >-
+      Prefixo para nomes de sessão de Controle Remoto gerados automaticamente, visível
+      no claude.ai/code e no aplicativo móvel do Claude. O padrão é "HomeAssistant",
+      gerando nomes como "HomeAssistant-graceful-unicorn". Aplicável apenas quando o Controle Remoto está habilitado.
 
 network:
   7681/tcp: Terminal Web (ttyd)


### PR DESCRIPTION
- enable_remote_control: automatically starts Claude Code with Remote Control enabled by setting remoteControlAtStartup: true in settings.json
- remote_control_session_prefix: sets the session name prefix via CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX (only when RC is enabled), defaults to "HomeAssistant"

The main motivation is that controlling Claude Code in the terminal in HA web UI sucks on Android (mobile keyboard is not really made for this), so having a persistent session that I can control via Claude mobile app is much better experience. Thanks a lot for this add-on!