### PR TITLE
Fix clipboard copy on macOS in the web terminal (enable Option+drag selection)

### DIFF
--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.66] - 2026-07-26
+
+### Fixed
+- Copying text from the web terminal was impossible on macOS whenever the program in the pane enabled mouse tracking - which is the normal state of this add-on: tmux runs with `mouse on`, and Claude Code's fullscreen renderer captures the mouse too. ttyd's copy path is client-side (a native xterm.js selection is auto-copied with a brief scissors overlay), but xterm.js only allows bypassing application mouse-tracking with Shift+drag on Windows/Linux; on macOS the gesture is Option+drag and it is additionally gated behind the `macOptionClickForcesSelection` client option, which defaults to false. Mac users therefore had no working copy gesture at all. ttyd now starts with `-t macOptionClickForcesSelection=true`, so Option+drag makes a native selection that lands on the system clipboard. Verified against the shipped ttyd 1.7.7 binary and web client. A full fix (OSC 52, letting tmux and CLI apps write the clipboard directly) needs a newer xterm.js than any released ttyd bundles: 1.7.7 (2024-03) is still the latest release; ttyd's main branch has `@xterm/addon-clipboard` and could be served via `ttyd --index` in a future change
+- README copy/paste instructions updated to match: `Option (⌥)`+drag on macOS, `Shift`+drag on Windows/Linux (the previously documented `Ctrl+Shift` gesture never worked on macOS)
+
 ## [1.2.65] - 2026-07-08
 
 ### Security

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -298,6 +298,7 @@ CMD ["/bin/bash", "-c", "\
     -t fontSize=$FONT_SIZE \
     -t fontFamily=Monaco,Consolas,monospace \
     -t scrollback=20000 \
+    -t macOptionClickForcesSelection=true \
     -t \"theme=$COLORS\" \
     $SHELL_CMD \
 "]

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -156,9 +156,12 @@ Since tmux captures mouse events, copy/paste works differently:
 
 | Action | How to do it |
 |--------|--------------|
-| **Copy** | Hold `Ctrl+Shift` while selecting text with mouse |
+| **Copy (macOS)** | Hold `Option (⌥)` while selecting text with the mouse |
+| **Copy (Windows/Linux)** | Hold `Shift` while selecting text with the mouse |
 | **Paste** | `Shift+Insert` or middle-click |
 | **Alternative paste** | `Ctrl+Shift+V` (browser dependent) |
+
+Holding the modifier makes the browser terminal handle the selection natively instead of passing the mouse to tmux; the selection is copied to your clipboard automatically the moment you release the button — watch for the brief ✂ icon as confirmation.
 
 **Note**: Regular right-click paste and simple mouse selection won't work because tmux intercepts these events for scrolling.
 
@@ -171,7 +174,7 @@ The authentication URL can be long and may wrap across multiple lines. To handle
 3. Complete authentication in the browser and **copy the auth code**
 4. Click back on the terminal and **paste** with `Shift+Insert` or `Ctrl+Shift+V`
 
-If clicking the link doesn't work, hold `Ctrl+Shift` while selecting the URL with your mouse to copy it, then paste it into your browser's address bar.
+If clicking the link doesn't work, hold `Shift` (`Option` on macOS) while selecting the URL with your mouse to copy it, then paste it into your browser's address bar.
 
 ### Scrolling and Session Persistence Trade-offs
 
@@ -181,6 +184,7 @@ If clicking the link doesn't work, hold `Ctrl+Shift` while selecting the URL wit
 - ✅ Long-running Claude tasks continue in background
 - ✅ Mouse wheel scrolling works (enters copy mode automatically)
 - ✅ 20,000 line scrollback buffer
+- ✅ Copy by holding `Shift` (Windows/Linux) or `Option ⌥` (macOS) while selecting
 - ⚠️ Use middle-click or Shift+Insert to paste (right-click paste may not work)
 
 **Without tmux (`session_persistence: false`):**

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.65"
+version: "1.2.66"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:


### PR DESCRIPTION
## Problem

On macOS there is currently no way to copy text out of the web terminal with tmux mouse on.

## Root cause

- ttyd's copy path is client-side: a native xterm.js selection is auto-copied on mouse-release (`document.execCommand("copy")` + the ✂ overlay). No native selection → no copy.
- When an app enables mouse tracking, xterm.js only offers a modifier gesture to bypass it and select natively: Shift+drag on Windows/Linux, Option+drag on macOS — and **the macOS native selection gesture is gated behind the `macOptionClickForcesSelection` client option, which defaults to `false`**:

  ```js
  shouldForceSelection(ev) {
    return isMac ? ev.altKey && opts.macOptionClickForcesSelection : ev.shiftKey;
  }
  ```

  So on a Mac there is no working bypass at all.
- The other standard escape — OSC 52, where tmux/CLI apps write the clipboard through the terminal — is unavailable here: ttyd 1.7.7's bundled xterm.js predates `@xterm/addon-clipboard`, and 1.7.7 (2024-03) is still ttyd's latest release.

## Fix

Start ttyd with `-t macOptionClickForcesSelection=true`. Option(⌥)+drag then makes a native selection, which ttyd auto-copies to the system clipboard. No behavior change for plain drags, for other client options, or for non-Mac users (the option is consulted on macOS only).

Also updates the README's copy/paste sections to document the working gestures — `Option (⌥)`+drag on macOS, `Shift`+drag on Windows/Linux — and the ✂ auto-copy behavior. The previously documented `Ctrl+Shift`+select gesture never worked on macOS.

## Testing

Ran a second instance of the shipped ttyd 1.7.7 binary (same embedded web client) inside a running add-on container with the new flag, attached to a tmux session with `mouse on`, accessed from Chrome on macOS over plain HTTP:

- plain drag: captured by tmux, nothing reaches the clipboard (unchanged)
- **Option+drag: native selection, ✂ overlay, text lands on the macOS clipboard** ✓

## Future work

ttyd's main branch bundles `@xterm/addon-clipboard` (OSC 52), but it has never been released. Building just its web client (`html/`, a Node-only build) and serving it via `ttyd --index` on the stable 1.7.7 server would make copy work regardless of who owns the mouse, and would benefit all platforms.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)