### PR TITLE
fix(claudecode): work around broken login URL copy (v1.2.66)

### DIFF
--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.66] - 2026-07-30
+
+### Added
+- `claude-login-url` command: pulls the OAuth login URL out of the `claude` tmux session (via `tmux capture-pane -J`, which rejoins soft-wrapped lines) and saves it to `/homeassistant/claude-login-url.txt`. Works around two upstream limitations that otherwise block signing in: ttyd's bundled xterm.js does not implement OSC 52 clipboard writes, so the CLI's own "press `c` to copy" hint is a no-op here; and its link detector only scans one rendered terminal row at a time, so a login URL that wraps across lines never becomes a single clickable link either. Documented in the README's authentication section
+
 ## [1.2.65] - 2026-07-08
 
 ### Security

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -117,6 +117,12 @@ RUN mkdir -p \
 COPY rootfs/root/.tmux.conf /root/.tmux.conf
 COPY rootfs/root/.bashrc /root/.bashrc
 
+# Helper to pull the OAuth login URL out of the tmux session and save it to a
+# file, working around ttyd/xterm.js not supporting OSC 52 clipboard writes
+# and its link detector only scanning one wrapped row at a time.
+COPY rootfs/usr/local/bin/claude-login-url /usr/local/bin/claude-login-url
+RUN chmod +x /usr/local/bin/claude-login-url
+
 # Ensure .bashrc is sourced for login shells too
 RUN echo 'source ~/.bashrc' > /root/.profile
 

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -164,14 +164,17 @@ Since tmux captures mouse events, copy/paste works differently:
 
 #### Authenticating Claude Code (first launch)
 
-The authentication URL can be long and may wrap across multiple lines. To handle this:
+The login URL is long, wraps across multiple lines in the terminal, and the CLI's own "press `c` to copy" hint does nothing here — ttyd's bundled xterm.js doesn't implement OSC 52 clipboard writes, and its link detector only scans one rendered row at a time, so a wrapped URL never becomes one clickable link either. Recommended:
 
-1. **Zoom out** your browser (`Ctrl + -` or `Cmd + -`) until the URL fits on a single line
-2. **Click the link** — it should open in a new tab
-3. Complete authentication in the browser and **copy the auth code**
-4. Click back on the terminal and **paste** with `Shift+Insert` or `Ctrl+Shift+V`
+1. Run `claude` (or `/login` inside it) to print the login URL
+2. Open a second tmux window: `Ctrl+b c`
+3. Run `claude-login-url` — it reassembles the full URL from the first window's scrollback (even wrapped) and saves it to `/homeassistant/claude-login-url.txt`
+4. Open that file with the Home Assistant File Editor add-on (or over Samba), copy the whole line, and open it in your browser
+5. Complete authentication and **copy the auth code**
+6. Switch back to the first tmux window (`Ctrl+b p`) and **paste** the code with `Shift+Insert` or `Ctrl+Shift+V`
+7. Delete `claude-login-url.txt` when done — it lives in your config directory, which is included in HA backups
 
-If clicking the link doesn't work, hold `Ctrl+Shift` while selecting the URL with your mouse to copy it, then paste it into your browser's address bar.
+If you're running with `session_persistence: false` (no tmux), `claude-login-url` isn't available, but native browser copy/paste works directly: **zoom out** your browser (`Ctrl + -` or `Cmd + -`) until the URL fits on a single line, then select and copy it normally.
 
 ### Scrolling and Session Persistence Trade-offs
 
@@ -216,7 +219,7 @@ Claude Code manages its own authentication. If you have issues:
 2. Follow the prompts to log in or enter your API key
 3. Credentials are saved automatically for future sessions
 
-**Can't copy the URL or paste the auth code?** The terminal uses tmux, which changes how copy/paste works. See [Copy and Paste in tmux](#copy-and-paste-in-tmux) for instructions.
+**Can't copy the URL or paste the auth code?** The terminal uses tmux, which changes how copy/paste works, and the CLI's own "press `c` to copy" hint doesn't work in this browser terminal (see [Authenticating Claude Code](#authenticating-claude-code-first-launch) for the `claude-login-url` workaround). See [Copy and Paste in tmux](#copy-and-paste-in-tmux) for general copy/paste instructions.
 
 ### hass-mcp not working
 

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.65"
+version: "1.2.66"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:

--- a/claudecode/rootfs/usr/local/bin/claude-login-url
+++ b/claudecode/rootfs/usr/local/bin/claude-login-url
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# claude-login-url — extract the most recent OAuth login URL from the Claude
+# tmux session and save it to /homeassistant, where it can be opened via the
+# Home Assistant File Editor or Samba and copied without going through the
+# terminal at all.
+#
+# Why: ttyd's bundled xterm.js doesn't implement OSC 52 clipboard writes, so
+# the "press c to copy" hint in `claude`'s /login is a no-op here. Its
+# built-in link detector also only scans one rendered row at a time, so a
+# long OAuth URL that wraps across lines never becomes a single clickable
+# link either. `tmux capture-pane -J` joins soft-wrapped lines back into one
+# logical line, so the URL comes out intact regardless of terminal width.
+
+OUT="${1:-/homeassistant/claude-login-url.txt}"
+SESSION="claude"
+
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "No tmux session named '$SESSION' found." >&2
+    echo "This command needs session_persistence: true (the default)." >&2
+    echo "With session_persistence off there is no tmux, but your browser's" >&2
+    echo "native selection/copy works directly instead." >&2
+    exit 1
+fi
+
+url=$(tmux capture-pane -p -J -t "$SESSION" -S -500 2>/dev/null \
+    | grep -oE "https://(claude\.(com|ai)|console\.anthropic\.com|platform\.claude\.com)[^[:space:]\"'\`)<>]*" \
+    | tail -1)
+
+if [ -z "$url" ]; then
+    echo "No login URL found in the Claude session." >&2
+    echo "Run 'claude' or '/login' first, then run this command again." >&2
+    exit 1
+fi
+
+printf '%s\n' "$url" > "$OUT"
+chmod 600 "$OUT"
+
+echo "Login URL saved to: $OUT"
+echo "Open it with the Home Assistant File Editor (or over Samba), copy the"
+echo "whole line into your browser, and authorize. Delete the file afterwards -"
+echo "it lives in your config directory, which is included in HA backups."


### PR DESCRIPTION
## Summary
- ttyd's bundled xterm.js doesn't implement OSC 52 clipboard writes, so `claude`'s "press `c` to copy" hint on `/login` silently does nothing in this add-on's terminal
- Its link detector also only scans one rendered row at a time, so a login URL that wraps across lines never becomes a single clickable link either
- Adds `claude-login-url`, a helper that pulls the URL out of the `claude` tmux session via `tmux capture-pane -J` (which rejoins soft-wrapped lines) and saves it to `/homeassistant/claude-login-url.txt`, so it can be opened via the File Editor add-on or Samba and copied normally, bypassing the terminal entirely
- README's authentication section now leads with this workflow; the old browser-zoom trick is kept as a fallback for `session_persistence: false` (no tmux)
- Version bumped to 1.2.66 with a CHANGELOG entry per this repo's contribution rules

## Test plan
- [ ] `bash -n` syntax check on `claude-login-url` (done locally)
- [ ] Build the `claudecode` add-on image and confirm `claude-login-url` is present and executable at `/usr/local/bin/claude-login-url`
- [ ] With `session_persistence: true`, start `claude`, trigger `/login`, run `claude-login-url` from a second tmux window, and confirm `/homeassistant/claude-login-url.txt` contains the full, unwrapped OAuth URL
- [ ] With `session_persistence: false`, confirm `claude-login-url` prints a clear error pointing at the browser-zoom fallback instead of failing silently