### PR TITLE
chore(claudecode): stop baking the npm cache into the image (v1.2.67)

### DIFF
--- a/claudecode/.dockerignore
+++ b/claudecode/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the build context small. Only the Dockerfile, install-claude.sh, and
+# rootfs/ are actually needed inside the image build; everything below is
+# add-on metadata, docs, or assets consumed by HA Supervisor, not the image.
+.git
+.gitignore
+*.png
+README.md
+CHANGELOG.md
+config.yaml
+build.yaml
+apparmor.txt
+translations/

--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.66] - 2026-08-14
+
+### Added
+- **Working clipboard integration (OSC 52) in the web terminal.** The web
+  client embedded in the ttyd 1.7.7 binary bundles xterm.js 5.4 without the
+  clipboard addon, so OSC 52 writes were silently dropped — the Claude CLI's
+  "press `c` to copy" hint did nothing, and tmux copies never reached the
+  system clipboard. ttyd now serves a newer web client (xterm.js 5.5 +
+  `@xterm/addon-clipboard`) via `--index`; the 1.7.7 binary is unchanged.
+  The client is compiled in a Dockerfile build stage from a pinned ttyd main
+  commit (2922cb8), with yarn honoring the upstream lockfile — the build is
+  reproducible (byte-identical output across runs) and every input is
+  pinned, so nothing drifts between builds.
+  tmux is configured with `set-clipboard on` plus an `Ms` terminal-override
+  pinned to the `c` selection (tmux fills `%p1` with `""` for its own copies
+  and `c` for programs; the clipboard addon drops anything that isn't exactly
+  `c`, so the override prints `%p1` with zero precision and hardcodes `c`).
+  Verified with a headless Chromium against the shipped 1.7.7 binary,
+  including end-to-end from a full amd64 image build: typing, resize, window
+  title, program-initiated OSC 52 (the "press `c`" path), and tmux
+  buffer/copy-mode copies all work. Because tmux stores wrapped output as
+  one logical line, copy-mode copies of the wrapped login URL come out
+  intact — the problem #38 works around, solved at the root.
+  The newer client also helps plain-HTTP setups: its link detector follows
+  URLs across soft-wrapped rows, so a wrapped login URL printed as flowing
+  output is clickable as one complete link, and a `Ctrl+Shift`-drag
+  selection over it copies as one unbroken line via `execCommand` — both
+  verified with the async clipboard API unavailable, as it is on plain HTTP.
+  Limitations, also verified: OSC 52 itself needs HTTPS or localhost —
+  on plain HTTP the write is dropped harmlessly and the drag gestures
+  remain the copy path; and rows painted by full-screen UIs with per-row
+  cursor positioning carry no wrap metadata, so click and drag there see
+  one row at a time (covered by `c`/OSC 52 on HTTPS, or the browser
+  zoom-out fallback). The main-branch client on a 1.7.7 server is an
+  unreleased pairing; the build stage and `--index` flag should be dropped
+  when the next ttyd release ships. README updated (copy table,
+  authentication flow, trade-offs list).
+
 ## [1.2.65] - 2026-07-08
 
 ### Security

--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.67] - 2026-08-17
+
+### Changed
+- Image size: the Claude Code install now runs `npm cache clean --force` and removes `/root/.npm` and `/tmp` in the same `RUN` layer. The package pulls a ~240MB platform-native binary via optional dependencies, so ~100MB+ of npm cache was being baked into the image
+
+### Added
+- `.dockerignore` keeps the Docker build context to just the `Dockerfile`, `install-claude.sh`, and `rootfs/` (docs, images, translations, and add-on metadata are consumed by the HA Supervisor, not the image build)
+
 ## [1.2.66] - 2026-08-17
 
 ### Added

--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.2.66] - 2026-08-14
+## [1.2.66] - 2026-08-17
 
 ### Added
 - **Working clipboard integration (OSC 52) in the web terminal.** The web
@@ -32,13 +32,35 @@ All notable changes to this project will be documented in this file.
   verified with the async clipboard API unavailable, as it is on plain HTTP.
   Limitations, also verified: OSC 52 itself needs HTTPS or localhost —
   on plain HTTP the write is dropped harmlessly and the drag gestures
-  remain the copy path; and rows painted by full-screen UIs with per-row
-  cursor positioning carry no wrap metadata, so click and drag there see
-  one row at a time (covered by `c`/OSC 52 on HTTPS, or the browser
-  zoom-out fallback). The main-branch client on a 1.7.7 server is an
-  unreleased pairing; the build stage and `--index` flag should be dropped
-  when the next ttyd release ships. README updated (copy table,
-  authentication flow, trade-offs list).
+  remain the copy path; and rows painted by full-screen UIs carry no wrap
+  metadata, so drag-selection there still sees one row at a time (the
+  click covers the login URL — see below — with the browser zoom-out
+  trick as the text-selection fallback). The main-branch client on a
+  1.7.7 server is an unreleased pairing; the build stage and `--index`
+  flag should be dropped when the next ttyd release ships. README updated
+  (copy table, authentication flow, trade-offs list).
+- **The wrapped `/login` URL is clickable — and opens as one complete
+  link.** The login screen hard-wraps the OAuth URL into separate rows
+  (real newlines, no wrap metadata), so the link detector, drag-selection,
+  and click each saw only one row's fragment — and on plain HTTP, where
+  the `c` (OSC 52) copy hint is blocked by the browser, that left no
+  working path to log in. But the CLI prints every one of those rows
+  wrapped in an OSC 8 hyperlink whose metadata carries the *complete*
+  URL, and the xterm.js 5.5 client activates OSC 8 links out of the box.
+  The missing piece was tmux: it re-emits pane hyperlinks only when the
+  outer terminal declares the `hyperlinks` terminal-feature, which its
+  default `xterm*` feature list lacks — so the links were silently
+  stripped. A one-line `terminal-features` override in `.tmux.conf`
+  fixes it (needs tmux ≥ 3.4; the Alpine 3.21 base ships 3.5a). Clicking
+  any row of the wrapped URL now opens the complete OAuth URL in a new
+  tab after the terminal's confirmation dialog — a navigation, not a
+  clipboard write, so it works on plain HTTP too. Verified by replaying
+  a captured real `/login` byte stream (Claude Code 2.1.233) through the
+  shipped ttyd 1.7.7 binary plus the built web client in a headless
+  Chromium: without the override a click opened only the truncated
+  first-row fragment; with it, clicks on the first row and on a
+  continuation row each opened the full URL, and tmux OSC 52 copies
+  still landed on the clipboard.
 
 ## [1.2.65] - 2026-07-08
 

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -86,8 +86,14 @@ COPY --from=ttyd-client /ttyd/html/dist/inline.html /usr/share/ttyd/index.html
 # SIGILL). Fix that at the hypervisor (Proxmox CPU type "host"), not here.
 # No version is hardcoded: take latest when it runs, otherwise the newest
 # release that passes a smoke test, so the add-on still builds on such hosts.
+# The package pulls a ~240MB platform-native binary via optional deps, so clean
+# the npm cache and temp dirs in the SAME layer - otherwise ~100MB+ of cache
+# gets baked into the image.
 COPY install-claude.sh /usr/local/bin/install-claude.sh
-RUN chmod +x /usr/local/bin/install-claude.sh && /usr/local/bin/install-claude.sh
+RUN chmod +x /usr/local/bin/install-claude.sh \
+    && /usr/local/bin/install-claude.sh \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /tmp/*
 
 # Install hass-mcp for Home Assistant integration and pymodbus for Modbus operations
 RUN pip3 install --no-cache-dir --break-system-packages hass-mcp pymodbus pyserial

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -1,17 +1,13 @@
 ARG BUILD_FROM
 
-# Build a current ttyd web client. The client embedded in the ttyd 1.7.7
-# binary predates OSC 52 clipboard support (xterm.js 5.4, no clipboard addon),
-# so startup serves this one via --index instead. Built from a pinned ttyd
-# main commit with yarn (via corepack, fetched from the npm registry) so
-# yarn.lock is honored - a plain npm install resolves newer transitive deps
-# and fails type-checking. Everything is pinned (ttyd commit, corepack, and
-# the lockfile-resolved deps) so the output is reproducible and nothing
-# drifts between builds. COREPACK_INTEGRITY_KEYS=0 keeps a pinned corepack
-# working across npm signing-key rotations (which have broken pinned
-# corepacks before); transport is TLS and dependency integrity comes from
-# the yarn.lock checksums. Drop this stage and the --index flag once a ttyd
-# release newer than 1.7.7 ships and the download below is bumped.
+# Build a current ttyd web client: the one embedded in the ttyd 1.7.7 binary
+# predates OSC 52 clipboard support, so startup serves this build via --index.
+# Built with yarn so ttyd's lockfile is honored (npm resolves newer transitive
+# deps and fails type-checking). Everything is pinned - ttyd commit, corepack,
+# lockfile deps - so the output is reproducible. COREPACK_INTEGRITY_KEYS=0
+# keeps the pinned corepack working across npm signing-key rotations;
+# integrity comes from the yarn.lock checksums. Drop this stage and the
+# --index flag once a ttyd release newer than 1.7.7 ships.
 FROM ${BUILD_FROM} AS ttyd-client
 RUN apk add --no-cache curl nodejs npm
 ARG TTYD_CLIENT_COMMIT=2922cb89f518bae4d0fcf4d757a7419638fc71fc

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -1,4 +1,30 @@
 ARG BUILD_FROM
+
+# Build a current ttyd web client. The client embedded in the ttyd 1.7.7
+# binary predates OSC 52 clipboard support (xterm.js 5.4, no clipboard addon),
+# so startup serves this one via --index instead. Built from a pinned ttyd
+# main commit with yarn (via corepack, fetched from the npm registry) so
+# yarn.lock is honored - a plain npm install resolves newer transitive deps
+# and fails type-checking. Everything is pinned (ttyd commit, corepack, and
+# the lockfile-resolved deps) so the output is reproducible and nothing
+# drifts between builds. COREPACK_INTEGRITY_KEYS=0 keeps a pinned corepack
+# working across npm signing-key rotations (which have broken pinned
+# corepacks before); transport is TLS and dependency integrity comes from
+# the yarn.lock checksums. Drop this stage and the --index flag once a ttyd
+# release newer than 1.7.7 ships and the download below is bumped.
+FROM ${BUILD_FROM} AS ttyd-client
+RUN apk add --no-cache curl nodejs npm
+ARG TTYD_CLIENT_COMMIT=2922cb89f518bae4d0fcf4d757a7419638fc71fc
+RUN curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+        "https://github.com/tsl0922/ttyd/archive/${TTYD_CLIENT_COMMIT}.tar.gz" \
+        | tar xz && mv "ttyd-${TTYD_CLIENT_COMMIT}" /ttyd
+WORKDIR /ttyd/html
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+    COREPACK_NPM_REGISTRY=https://registry.npmjs.org \
+    COREPACK_INTEGRITY_KEYS=0
+RUN npm install -g corepack@0.35.0 && corepack enable && \
+    yarn install --immutable && yarn run inline
+
 FROM ${BUILD_FROM}
 
 # Labels
@@ -42,7 +68,8 @@ RUN apk add --no-cache \
     docker-cli \
     && update-ca-certificates
 
-# Install ttyd static binary (avoids libwebsockets issues)
+# Install ttyd static binary (avoids libwebsockets issues); the web client
+# it serves comes from the ttyd-client build stage above (see --index).
 ARG BUILD_ARCH
 RUN case "${BUILD_ARCH}" in \
         amd64) TTYD_ARCH="x86_64" ;; \
@@ -54,6 +81,7 @@ RUN case "${BUILD_ARCH}" in \
     curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
         "https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.${TTYD_ARCH}" -o /usr/bin/ttyd && \
     chmod +x /usr/bin/ttyd
+COPY --from=ttyd-client /ttyd/html/dist/inline.html /usr/share/ttyd/index.html
 
 # Install Claude Code.
 # 2.1.113 replaced the JS entrypoint with a Bun-compiled native binary, whose
@@ -295,6 +323,7 @@ CMD ["/bin/bash", "-c", "\
   if [ \"$REMOTE_CONTROL\" = \"true\" ]; then export CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX=\"$RC_SESSION_PREFIX\"; fi && \
   cd /homeassistant && \
   exec ttyd --port 7681 --writable --ping-interval 30 --max-clients 5 \
+    --index /usr/share/ttyd/index.html \
     -t fontSize=$FONT_SIZE \
     -t fontFamily=Monaco,Consolas,monospace \
     -t scrollback=20000 \

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -156,22 +156,24 @@ Since tmux captures mouse events, copy/paste works differently:
 
 | Action | How to do it |
 |--------|--------------|
+| **Copy (tmux copy-mode)** | Scroll up (enters copy-mode), select, then copy — lands directly on your clipboard¹ |
 | **Copy** | Hold `Ctrl+Shift` while selecting text with mouse |
 | **Paste** | `Shift+Insert` or middle-click |
 | **Alternative paste** | `Ctrl+Shift+V` (browser dependent) |
+
+¹ Clipboard integration (OSC 52) requires accessing Home Assistant over **HTTPS or localhost** — browsers block programmatic clipboard writes on plain HTTP. On plain HTTP, use the modifier-key gesture instead. A bonus of OSC 52: copy-mode copies wrapped lines as one logical line, so long URLs come out intact.
 
 **Note**: Regular right-click paste and simple mouse selection won't work because tmux intercepts these events for scrolling.
 
 #### Authenticating Claude Code (first launch)
 
-The authentication URL can be long and may wrap across multiple lines. To handle this:
+If you access Home Assistant over **HTTPS** (or localhost), the CLI's own **press `c` to copy** hint works — the login URL lands directly on your clipboard via OSC 52. Paste it into a new tab, authenticate, copy the auth code, and **paste** it back into the terminal with `Shift+Insert` or `Ctrl+Shift+V`.
 
-1. **Zoom out** your browser (`Ctrl + -` or `Cmd + -`) until the URL fits on a single line
-2. **Click the link** — it should open in a new tab
-3. Complete authentication in the browser and **copy the auth code**
-4. Click back on the terminal and **paste** with `Shift+Insert` or `Ctrl+Shift+V`
+On plain HTTP the browser blocks programmatic clipboard writes, so `c` won't work — but the terminal's link detection follows URLs across wrapped lines, so usually you can simply **click the URL** even when it spans several rows, or hold `Ctrl+Shift` and select it with the mouse — the selection is copied as one unbroken line.
 
-If clicking the link doesn't work, hold `Ctrl+Shift` while selecting the URL with your mouse to copy it, then paste it into your browser's address bar.
+If clicking or selecting only picks up part of the URL (this can happen when a full-screen UI redraws the screen row by row instead of letting text flow), **zoom out** your browser (`Ctrl + -` or `Cmd + -`) until the URL fits on a single line and click or select it there.
+
+Either way: complete authentication in the browser, **copy the auth code**, click back on the terminal, and **paste** it with `Shift+Insert` or `Ctrl+Shift+V`.
 
 ### Scrolling and Session Persistence Trade-offs
 
@@ -181,6 +183,7 @@ If clicking the link doesn't work, hold `Ctrl+Shift` while selecting the URL wit
 - ✅ Long-running Claude tasks continue in background
 - ✅ Mouse wheel scrolling works (enters copy mode automatically)
 - ✅ 20,000 line scrollback buffer
+- ✅ Copy-mode copies and `claude`'s "press `c` to copy" go straight to your clipboard (HTTPS/localhost only)
 - ⚠️ Use middle-click or Shift+Insert to paste (right-click paste may not work)
 
 **Without tmux (`session_persistence: false`):**

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -161,19 +161,19 @@ Since tmux captures mouse events, copy/paste works differently:
 | **Paste** | `Shift+Insert` or middle-click |
 | **Alternative paste** | `Ctrl+Shift+V` (browser dependent) |
 
-¹ Clipboard integration (OSC 52) requires accessing Home Assistant over **HTTPS or localhost** — browsers block programmatic clipboard writes on plain HTTP. On plain HTTP, use the modifier-key gesture instead. A bonus of OSC 52: copy-mode copies wrapped lines as one logical line, so long URLs come out intact.
+¹ OSC 52 needs **HTTPS or localhost** — on plain HTTP, use the modifier-key gesture instead. Bonus: copy-mode copies wrapped lines as one logical line, so long URLs come out intact.
 
 **Note**: Regular right-click paste and simple mouse selection won't work because tmux intercepts these events for scrolling.
 
 #### Authenticating Claude Code (first launch)
 
-The simplest path works everywhere, including plain HTTP: **click the URL**. The login screen prints it as a real hyperlink (OSC 8), so even though it spans several rows, clicking *any* row opens the **complete** URL in a new tab after a confirmation dialog.
+**Click the URL** — this works everywhere, including plain HTTP. It's a real hyperlink (OSC 8): even though it wraps, any row opens the complete URL in a new tab after a confirmation prompt.
 
-If you access Home Assistant over **HTTPS** (or localhost), the CLI's own **press `c` to copy** hint also works — the login URL lands directly on your clipboard via OSC 52, ready to paste into a new tab. On plain HTTP the browser blocks programmatic clipboard writes, so `c` does nothing there — use the click.
+Over **HTTPS** (or localhost), the CLI's **press `c` to copy** hint also works via OSC 52. On plain HTTP browsers block clipboard writes — use the click.
 
-Avoid selecting the login URL with a `Ctrl+Shift`-drag: the login screen paints each row as a separate line, so the selection stitches the fragments together with line breaks. If you really need the URL as text, **zoom out** your browser (`Ctrl + -` or `Cmd + -`) until it fits on a single line first.
+Don't drag-select the URL: its rows are separate lines and copy with line breaks. If you need it as text, **zoom out** (`Ctrl + -` / `Cmd + -`) until it fits on one line.
 
-Either way: complete authentication in the browser, **copy the auth code**, click back on the terminal, and **paste** it with `Shift+Insert` or `Ctrl+Shift+V`.
+Then authenticate in the browser, copy the auth code, and paste it back with `Shift+Insert` or `Ctrl+Shift+V`.
 
 ### Scrolling and Session Persistence Trade-offs
 
@@ -184,7 +184,7 @@ Either way: complete authentication in the browser, **copy the auth code**, clic
 - ✅ Mouse wheel scrolling works (enters copy mode automatically)
 - ✅ 20,000 line scrollback buffer
 - ✅ Copy-mode copies and `claude`'s "press `c` to copy" go straight to your clipboard (HTTPS/localhost only)
-- ✅ Hyperlinks (OSC 8), like the wrapped `/login` URL, open complete with a single click
+- ✅ OSC 8 hyperlinks (e.g. the `/login` URL) open complete with one click
 - ⚠️ Use middle-click or Shift+Insert to paste (right-click paste may not work)
 
 **Without tmux (`session_persistence: false`):**

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -167,11 +167,11 @@ Since tmux captures mouse events, copy/paste works differently:
 
 #### Authenticating Claude Code (first launch)
 
-If you access Home Assistant over **HTTPS** (or localhost), the CLI's own **press `c` to copy** hint works — the login URL lands directly on your clipboard via OSC 52. Paste it into a new tab, authenticate, copy the auth code, and **paste** it back into the terminal with `Shift+Insert` or `Ctrl+Shift+V`.
+The simplest path works everywhere, including plain HTTP: **click the URL**. The login screen prints it as a real hyperlink (OSC 8), so even though it spans several rows, clicking *any* row opens the **complete** URL in a new tab after a confirmation dialog.
 
-On plain HTTP the browser blocks programmatic clipboard writes, so `c` won't work — but the terminal's link detection follows URLs across wrapped lines, so usually you can simply **click the URL** even when it spans several rows, or hold `Ctrl+Shift` and select it with the mouse — the selection is copied as one unbroken line.
+If you access Home Assistant over **HTTPS** (or localhost), the CLI's own **press `c` to copy** hint also works — the login URL lands directly on your clipboard via OSC 52, ready to paste into a new tab. On plain HTTP the browser blocks programmatic clipboard writes, so `c` does nothing there — use the click.
 
-If clicking or selecting only picks up part of the URL (this can happen when a full-screen UI redraws the screen row by row instead of letting text flow), **zoom out** your browser (`Ctrl + -` or `Cmd + -`) until the URL fits on a single line and click or select it there.
+Avoid selecting the login URL with a `Ctrl+Shift`-drag: the login screen paints each row as a separate line, so the selection stitches the fragments together with line breaks. If you really need the URL as text, **zoom out** your browser (`Ctrl + -` or `Cmd + -`) until it fits on a single line first.
 
 Either way: complete authentication in the browser, **copy the auth code**, click back on the terminal, and **paste** it with `Shift+Insert` or `Ctrl+Shift+V`.
 
@@ -184,6 +184,7 @@ Either way: complete authentication in the browser, **copy the auth code**, clic
 - ✅ Mouse wheel scrolling works (enters copy mode automatically)
 - ✅ 20,000 line scrollback buffer
 - ✅ Copy-mode copies and `claude`'s "press `c` to copy" go straight to your clipboard (HTTPS/localhost only)
+- ✅ Hyperlinks (OSC 8), like the wrapped `/login` URL, open complete with a single click
 - ⚠️ Use middle-click or Shift+Insert to paste (right-click paste may not work)
 
 **Without tmux (`session_persistence: false`):**

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.65"
+version: "1.2.66"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.66"
+version: "1.2.67"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:

--- a/claudecode/rootfs/root/.tmux.conf
+++ b/claudecode/rootfs/root/.tmux.conf
@@ -7,24 +7,17 @@ set -g mouse on
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 
-# OSC 52 clipboard integration with the browser terminal (needs the ttyd web
-# client served via --index; the browser only allows clipboard writes over
-# HTTPS or localhost). set-clipboard on lets both tmux copies (copy-mode,
-# set-buffer -w) and programs inside tmux (e.g. `claude`'s "press c to copy")
-# reach the system clipboard. The Ms override pins the selection to "c":
-# tmux fills %p1 with "" for its own copies and "c" for programs, and the
-# terminal's clipboard addon drops anything that isn't exactly "c" - so %p1
-# is printed with zero precision (i.e. not at all) and "c" is hardcoded.
+# OSC 52 clipboard for the browser terminal (needs the --index web client;
+# browsers allow clipboard writes over HTTPS/localhost only). set-clipboard on
+# forwards tmux copies and inner programs' OSC 52 (claude's "press c to copy").
+# The Ms override hardcodes the "c" selection - the only one the terminal's
+# clipboard addon accepts - and drops %p1 with zero precision.
 set -s set-clipboard on
 set -as terminal-overrides ',xterm*:Ms=\E]52;c%p1%.0s;%p2%s\007'
 
-# Forward OSC 8 hyperlinks to the browser terminal. Claude Code prints its
-# /login URL as an OSC 8 hyperlink: the URL is hard-wrapped into separate
-# rows on screen, but every row carries the complete URL as link metadata,
-# and xterm.js makes each row clickable (opens the full URL). tmux only
-# re-emits hyperlinks when the outer terminal declares support, and its
-# default xterm* feature list does not include it - declare it explicitly.
-# Needs tmux >= 3.4 (the base image ships 3.5a).
+# Pass OSC 8 hyperlinks through to the browser terminal - claude's /login URL
+# is one; every wrapped row carries the full URL, so any row is clickable.
+# tmux drops hyperlinks unless the outer terminal declares support (tmux >= 3.4).
 set -as terminal-features ',xterm*:hyperlinks'
 
 # User overrides, loaded last so they win. This file lives in the Home Assistant

--- a/claudecode/rootfs/root/.tmux.conf
+++ b/claudecode/rootfs/root/.tmux.conf
@@ -7,6 +7,17 @@ set -g mouse on
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 
+# OSC 52 clipboard integration with the browser terminal (needs the ttyd web
+# client served via --index; the browser only allows clipboard writes over
+# HTTPS or localhost). set-clipboard on lets both tmux copies (copy-mode,
+# set-buffer -w) and programs inside tmux (e.g. `claude`'s "press c to copy")
+# reach the system clipboard. The Ms override pins the selection to "c":
+# tmux fills %p1 with "" for its own copies and "c" for programs, and the
+# terminal's clipboard addon drops anything that isn't exactly "c" - so %p1
+# is printed with zero precision (i.e. not at all) and "c" is hardcoded.
+set -s set-clipboard on
+set -as terminal-overrides ',xterm*:Ms=\E]52;c%p1%.0s;%p2%s\007'
+
 # User overrides, loaded last so they win. This file lives in the Home Assistant
 # config directory, so it survives restarts, rebuilds and reinstalls - unlike
 # /root/.tmux.conf, which is part of the container image. -q ignores it when absent.

--- a/claudecode/rootfs/root/.tmux.conf
+++ b/claudecode/rootfs/root/.tmux.conf
@@ -18,6 +18,15 @@ bind -n WheelDownPane select-pane -t= \; send-keys -M
 set -s set-clipboard on
 set -as terminal-overrides ',xterm*:Ms=\E]52;c%p1%.0s;%p2%s\007'
 
+# Forward OSC 8 hyperlinks to the browser terminal. Claude Code prints its
+# /login URL as an OSC 8 hyperlink: the URL is hard-wrapped into separate
+# rows on screen, but every row carries the complete URL as link metadata,
+# and xterm.js makes each row clickable (opens the full URL). tmux only
+# re-emits hyperlinks when the outer terminal declares support, and its
+# default xterm* feature list does not include it - declare it explicitly.
+# Needs tmux >= 3.4 (the base image ships 3.5a).
+set -as terminal-features ',xterm*:hyperlinks'
+
 # User overrides, loaded last so they win. This file lives in the Home Assistant
 # config directory, so it survives restarts, rebuilds and reinstalls - unlike
 # /root/.tmux.conf, which is part of the container image. -q ignores it when absent.


### PR DESCRIPTION
Note: Stacked on #44 — please merge that first. Until it merges, this diff also shows the parent PRs' commits; this PR's own change is the last commit (v1.2.67). Versions are sequential across the stack so there are no conflicts on config.yaml or the changelog.

The Claude Code install pulls a ~240MB platform-native binary through optional dependencies, leaving ~100MB+ of npm cache in the layer. Clean the cache and temp dirs in the same RUN so it never ships.

Also add a .dockerignore: docs, images, translations, and add-on metadata are consumed by the HA Supervisor directly, not by the image build, so they are excluded from the Docker build context.