### PR TITLE
feat(claudecode): extra_npm_packages option for persistent custom MCP servers (v1.2.70)

### DIFF
--- a/claudecode/.dockerignore
+++ b/claudecode/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the build context small. Only the Dockerfile, install-claude.sh, and
+# rootfs/ are actually needed inside the image build; everything below is
+# add-on metadata, docs, or assets consumed by HA Supervisor, not the image.
+.git
+.gitignore
+*.png
+README.md
+CHANGELOG.md
+config.yaml
+build.yaml
+apparmor.txt
+translations/

--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.66] - 2026-08-14
+
+### Added
+- **Working clipboard integration (OSC 52) in the web terminal.** The web
+  client embedded in the ttyd 1.7.7 binary bundles xterm.js 5.4 without the
+  clipboard addon, so OSC 52 writes were silently dropped — the Claude CLI's
+  "press `c` to copy" hint did nothing, and tmux copies never reached the
+  system clipboard. ttyd now serves a newer web client (xterm.js 5.5 +
+  `@xterm/addon-clipboard`) via `--index`; the 1.7.7 binary is unchanged.
+  The client is compiled in a Dockerfile build stage from a pinned ttyd main
+  commit (2922cb8), with yarn honoring the upstream lockfile — the build is
+  reproducible (byte-identical output across runs) and every input is
+  pinned, so nothing drifts between builds.
+  tmux is configured with `set-clipboard on` plus an `Ms` terminal-override
+  pinned to the `c` selection (tmux fills `%p1` with `""` for its own copies
+  and `c` for programs; the clipboard addon drops anything that isn't exactly
+  `c`, so the override prints `%p1` with zero precision and hardcodes `c`).
+  Verified with a headless Chromium against the shipped 1.7.7 binary,
+  including end-to-end from a full amd64 image build: typing, resize, window
+  title, program-initiated OSC 52 (the "press `c`" path), and tmux
+  buffer/copy-mode copies all work. Because tmux stores wrapped output as
+  one logical line, copy-mode copies of the wrapped login URL come out
+  intact — the problem #38 works around, solved at the root.
+  The newer client also helps plain-HTTP setups: its link detector follows
+  URLs across soft-wrapped rows, so a wrapped login URL printed as flowing
+  output is clickable as one complete link, and a `Ctrl+Shift`-drag
+  selection over it copies as one unbroken line via `execCommand` — both
+  verified with the async clipboard API unavailable, as it is on plain HTTP.
+  Limitations, also verified: OSC 52 itself needs HTTPS or localhost —
+  on plain HTTP the write is dropped harmlessly and the drag gestures
+  remain the copy path; and rows painted by full-screen UIs with per-row
+  cursor positioning carry no wrap metadata, so click and drag there see
+  one row at a time (covered by `c`/OSC 52 on HTTPS, or the browser
+  zoom-out fallback). The main-branch client on a 1.7.7 server is an
+  unreleased pairing; the build stage and `--index` flag should be dropped
+  when the next ttyd release ships. README updated (copy table,
+  authentication flow, trade-offs list).
+
 ## [1.2.65] - 2026-07-08
 
 ### Security

--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.67] - 2026-08-17
+
+### Changed
+- Image size: the Claude Code install now runs `npm cache clean --force` and removes `/root/.npm` and `/tmp` in the same `RUN` layer. The package pulls a ~240MB platform-native binary via optional dependencies, so ~100MB+ of npm cache was being baked into the image
+
+### Added
+- `.dockerignore` keeps the Docker build context to just the `Dockerfile`, `install-claude.sh`, and `rootfs/` (docs, images, translations, and add-on metadata are consumed by the HA Supervisor, not the image build)
+
 ## [1.2.66] - 2026-08-17
 
 ### Added

--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.69] - 2026-08-17
+
+### Fixed
+- Playwright Browser hostname auto-detection never worked: startup read `.hostname` from the Supervisor `/addons` list endpoint, but that endpoint doesn't return `hostname` (it only exists on `/addons/{slug}/info`), so detection always fell through to the literal `playwright-browser` fallback — which never resolves on HA's network (real add-on hostnames look like `<repo-id>-playwright-browser`). The hostname is now derived from the add-on `.slug` (underscores → hyphens; HA add-on hostnames are deterministic) by a small launcher script that runs each time the MCP server starts — so it also works when Playwright Browser is installed or started *after* Claude Code, without restarting this add-on. The `playwright_cdp_host` override still takes precedence
+- `@playwright/mcp` is now installed at build time under `/opt/playwright-mcp` (with a `playwright-mcp` symlink in `/usr/local/bin`) instead of relying on a pre-seeded npx cache. The `/opt` prefix avoids the `/usr/local/bin/mcp` binary-name collision with `hass-mcp`, the npm cache no longer ships in the image, and the MCP server no longer depends on npx cache state at runtime
+
 ## [1.2.68] - 2026-08-17
 
 ### Added

--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.68] - 2026-08-17
+
+### Added
+- `~/.claude/CLAUDE.user.md` — a user-managed instructions file, created empty and whose content the add-on never touches. It's imported by the add-on-managed `~/.claude/CLAUDE.md`, so anything you put there loads into every Claude Code session and survives restarts and add-on rebuilds. Created empty on purpose, and documented in the README rather than in the model-visible files: both `CLAUDE.md` and `CLAUDE.user.md` are fed to the model verbatim, so explanatory boilerplate in either would be injected into every session
+
+### Changed
+- The add-on-managed `~/.claude/CLAUDE.md` is now a static `CLAUDE.addon.md` file copied into the image, instead of a ~55-line escaped `printf` inside the Dockerfile `CMD`. Easier to maintain and review. Content is unchanged apart from the `CLAUDE.user.md` import added at the end — and the stray backslashes are gone: the printf's quoting wrote a literal `\` before every backtick into the generated file
+
 ## [1.2.67] - 2026-08-17
 
 ### Changed

--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.2.66] - 2026-08-14
+## [1.2.66] - 2026-08-17
 
 ### Added
 - **Working clipboard integration (OSC 52) in the web terminal.** The web
@@ -32,13 +32,35 @@ All notable changes to this project will be documented in this file.
   verified with the async clipboard API unavailable, as it is on plain HTTP.
   Limitations, also verified: OSC 52 itself needs HTTPS or localhost —
   on plain HTTP the write is dropped harmlessly and the drag gestures
-  remain the copy path; and rows painted by full-screen UIs with per-row
-  cursor positioning carry no wrap metadata, so click and drag there see
-  one row at a time (covered by `c`/OSC 52 on HTTPS, or the browser
-  zoom-out fallback). The main-branch client on a 1.7.7 server is an
-  unreleased pairing; the build stage and `--index` flag should be dropped
-  when the next ttyd release ships. README updated (copy table,
-  authentication flow, trade-offs list).
+  remain the copy path; and rows painted by full-screen UIs carry no wrap
+  metadata, so drag-selection there still sees one row at a time (the
+  click covers the login URL — see below — with the browser zoom-out
+  trick as the text-selection fallback). The main-branch client on a
+  1.7.7 server is an unreleased pairing; the build stage and `--index`
+  flag should be dropped when the next ttyd release ships. README updated
+  (copy table, authentication flow, trade-offs list).
+- **The wrapped `/login` URL is clickable — and opens as one complete
+  link.** The login screen hard-wraps the OAuth URL into separate rows
+  (real newlines, no wrap metadata), so the link detector, drag-selection,
+  and click each saw only one row's fragment — and on plain HTTP, where
+  the `c` (OSC 52) copy hint is blocked by the browser, that left no
+  working path to log in. But the CLI prints every one of those rows
+  wrapped in an OSC 8 hyperlink whose metadata carries the *complete*
+  URL, and the xterm.js 5.5 client activates OSC 8 links out of the box.
+  The missing piece was tmux: it re-emits pane hyperlinks only when the
+  outer terminal declares the `hyperlinks` terminal-feature, which its
+  default `xterm*` feature list lacks — so the links were silently
+  stripped. A one-line `terminal-features` override in `.tmux.conf`
+  fixes it (needs tmux ≥ 3.4; the Alpine 3.21 base ships 3.5a). Clicking
+  any row of the wrapped URL now opens the complete OAuth URL in a new
+  tab after the terminal's confirmation dialog — a navigation, not a
+  clipboard write, so it works on plain HTTP too. Verified by replaying
+  a captured real `/login` byte stream (Claude Code 2.1.233) through the
+  shipped ttyd 1.7.7 binary plus the built web client in a headless
+  Chromium: without the override a click opened only the truncated
+  first-row fragment; with it, clicks on the first row and on a
+  continuation row each opened the full URL, and tmux OSC 52 copies
+  still landed on the clipboard.
 
 ## [1.2.65] - 2026-07-08
 

--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.70] - 2026-08-17
+
+### Added
+- `extra_npm_packages` option: list of npm package specs to install on every container start under `/homeassistant/.claudecode/npm-global` (persistent across add-on rebuilds). The bin directory is on `PATH`. Use it to add custom MCP servers without forking the Dockerfile; a failed install logs a `[WARN]` but never blocks startup
+
 ## [1.2.69] - 2026-08-17
 
 ### Fixed

--- a/claudecode/CLAUDE.addon.md
+++ b/claudecode/CLAUDE.addon.md
@@ -1,0 +1,58 @@
+# Claude Code - Home Assistant Add-on
+
+## Path Mapping
+
+In this add-on container, paths are mapped differently than HA Core:
+- `/homeassistant` = HA config directory (equivalent to `/config` in HA Core)
+- `/config` does NOT exist - always use `/homeassistant`
+
+When users mention `/config/...`, translate to `/homeassistant/...`
+
+## Available Paths
+
+| Path | Description | Access |
+|------|-------------|--------|
+| `/homeassistant` | HA configuration | read-write |
+| `/share` | Shared folder | read-write |
+| `/media` | Media files | read-write |
+| `/ssl` | SSL certificates | read-only |
+| `/backup` | Backups | read-only |
+
+## Home Assistant Integration
+
+Use the `homeassistant` MCP server to query entities and call services.
+
+## Reading Home Assistant Logs
+
+**Log levels (from most to least verbose):**
+- `debug` - Only shown if explicitly enabled in configuration.yaml
+- `info` - General information, shown by default
+- `warning` - Warnings, always shown
+- `error` - Errors, always shown
+
+**Commands to read logs:**
+```bash
+# View recent logs (ha CLI)
+ha core logs 2>&1 | tail -100
+
+# Filter by keyword
+ha core logs 2>&1 | grep -i keyword
+
+# Filter errors only
+ha core logs 2>&1 | grep -iE "(error|exception)"
+
+# Alternative: read log file directly
+tail -100 /homeassistant/home-assistant.log
+```
+
+**To enable debug logging for an integration**, add to `configuration.yaml`:
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.YOUR_INTEGRATION: debug
+```
+
+**Key insight:** `_LOGGER.debug()` calls are invisible unless the logger level is set to debug. Use `_LOGGER.info()` or `_LOGGER.warning()` for logs that should always appear.
+
+@~/.claude/CLAUDE.user.md

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -165,8 +165,9 @@ RUN chmod +x /usr/local/bin/playwright-mcp-launch
 # Ensure .bashrc is sourced for login shells too
 RUN echo 'source ~/.bashrc' > /root/.profile
 
-# Set up PATH
-ENV PATH="/root/.local/bin:${PATH}"
+# Set up PATH. The extra_npm_packages install dir is on the persistent HA
+# volume so user-installed MCP servers survive add-on rebuilds.
+ENV PATH="/root/.local/bin:/homeassistant/.claudecode/npm-global/bin:${PATH}"
 
 # Set working directory
 WORKDIR /homeassistant
@@ -221,6 +222,13 @@ CMD ["/bin/bash", "-c", "\
     fi; \
   else \
     echo \"[INFO] Claude Code $BUILT_VERSION (verified at build time)\"; \
+  fi && \
+  EXTRA_NPM_PREFIX=/homeassistant/.claudecode/npm-global && \
+  EXTRA_PKGS=$(jq -r '.extra_npm_packages // [] | join(\" \")' /data/options.json) && \
+  if [ -n \"$EXTRA_PKGS\" ]; then \
+    mkdir -p \"$EXTRA_NPM_PREFIX\" && \
+    echo \"[INFO] Installing extra_npm_packages: $EXTRA_PKGS\" && \
+    npm install -g --prefix=\"$EXTRA_NPM_PREFIX\" $EXTRA_PKGS 2>&1 | tail -5 || echo '[WARN] Some extra_npm_packages failed to install'; \
   fi && \
   if timeout 30 claude --version < /dev/null > /dev/null 2>&1; then \
     CLAUDE_OK=true; \

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -114,9 +114,16 @@ RUN apk add --no-cache --virtual .build-deps \
     && apk del .build-deps \
     && apk add --no-cache libmodbus
 
-# Pre-cache Playwright MCP server (npx cache avoids /usr/local/bin/mcp conflict with hass-mcp)
-ENV NPM_CONFIG_CACHE=/root/.npm
-RUN npx @playwright/mcp --version || true
+# Install @playwright/mcp into /opt to avoid colliding with hass-mcp's
+# /usr/local/bin/mcp (both packages would otherwise install a binary named
+# `mcp` at the same path). Then symlink the actual playwright-mcp binary
+# (different name, no collision) into /usr/local/bin so it lives in PATH and
+# in a conventional location — Claude Code's `auto` permission classifier
+# treats /opt as unusual.
+RUN npm install -g --prefix=/opt/playwright-mcp @playwright/mcp && \
+    ln -s /opt/playwright-mcp/bin/playwright-mcp /usr/local/bin/playwright-mcp && \
+    npm cache clean --force && \
+    rm -rf /root/.npm /tmp/*
 
 # Install Home Assistant CLI (ha command)
 # Pinned and retried: a transient DNS failure used to abort the whole build
@@ -150,6 +157,11 @@ COPY CLAUDE.addon.md /usr/share/claudecode/CLAUDE.addon.md
 COPY rootfs/root/.tmux.conf /root/.tmux.conf
 COPY rootfs/root/.bashrc /root/.bashrc
 
+# Playwright MCP launcher: resolves the Playwright Browser hostname each time
+# the MCP server starts (see the script for why this can't happen at boot).
+COPY rootfs/usr/local/bin/playwright-mcp-launch /usr/local/bin/playwright-mcp-launch
+RUN chmod +x /usr/local/bin/playwright-mcp-launch
+
 # Ensure .bashrc is sourced for login shells too
 RUN echo 'source ~/.bashrc' > /root/.profile
 
@@ -182,16 +194,6 @@ CMD ["/bin/bash", "-c", "\
   ENABLE_MCP=$(jq -r 'if .enable_mcp == null then true else .enable_mcp end' /data/options.json) && \
   ENABLE_PLAYWRIGHT=$(jq -r '.enable_playwright_mcp // false' /data/options.json) && \
   PLAYWRIGHT_HOST=$(jq -r '.playwright_cdp_host // \"\"' /data/options.json) && \
-  if [ -z \"$PLAYWRIGHT_HOST\" ] && [ \"$ENABLE_PLAYWRIGHT\" = \"true\" ]; then \
-    echo '[INFO] Auto-detecting Playwright Browser hostname...' && \
-    PLAYWRIGHT_HOST=$(curl -s -H \"Authorization: Bearer $SUPERVISOR_TOKEN\" http://supervisor/addons | jq -r '.data.addons[] | select(.slug | endswith(\"playwright-browser\") or endswith(\"_playwright-browser\")) | .hostname' | head -1) && \
-    if [ -n \"$PLAYWRIGHT_HOST\" ] && [ \"$PLAYWRIGHT_HOST\" != \"null\" ]; then \
-      echo \"[INFO] Found Playwright Browser: $PLAYWRIGHT_HOST\"; \
-    else \
-      echo '[WARN] Playwright Browser add-on not found, using default hostname'; \
-      PLAYWRIGHT_HOST=\"playwright-browser\"; \
-    fi; \
-  fi && \
   REMOTE_CONTROL=$(jq -r '.enable_remote_control // false' /data/options.json) && \
   RC_SESSION_PREFIX=$(jq -r '.remote_control_session_prefix // \"HomeAssistant\"' /data/options.json) && \
   SETTINGS_FILE=/root/.claude/settings.json && \
@@ -244,9 +246,13 @@ CMD ["/bin/bash", "-c", "\
     echo '[INFO] MCP disabled'; \
   fi && \
   if [ \"$CLAUDE_OK\" = \"true\" ] && [ \"$ENABLE_PLAYWRIGHT\" = \"true\" ]; then \
-    timeout 30 claude mcp add-json playwright \"{\\\"command\\\":\\\"npx\\\",\\\"args\\\":[\\\"--no-install\\\",\\\"@playwright/mcp\\\",\\\"--cdp-endpoint\\\",\\\"http://${PLAYWRIGHT_HOST}:9222\\\"]}\" -s user && \
-    echo \"[INFO] Playwright MCP enabled (CDP: http://${PLAYWRIGHT_HOST}:9222)\"; \
-    echo '[INFO] Make sure the Playwright Browser add-on is installed and running'; \
+    PW_MCP_JSON=$(jq -nc --arg host \"$PLAYWRIGHT_HOST\" '{command:\"/usr/local/bin/playwright-mcp-launch\", env:{PLAYWRIGHT_CDP_HOST:$host}}') && \
+    timeout 30 claude mcp add-json playwright \"$PW_MCP_JSON\" -s user && \
+    if [ -n \"$PLAYWRIGHT_HOST\" ]; then \
+      echo \"[INFO] Playwright MCP enabled (host override: $PLAYWRIGHT_HOST)\"; \
+    else \
+      echo '[INFO] Playwright MCP enabled (hostname auto-detected each time the MCP server starts)'; \
+    fi; \
   elif [ \"$ENABLE_PLAYWRIGHT\" = \"true\" ]; then \
     echo '[WARN] Playwright MCP is enabled but was skipped: the claude CLI is not responding'; \
   else \

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -86,8 +86,14 @@ COPY --from=ttyd-client /ttyd/html/dist/inline.html /usr/share/ttyd/index.html
 # SIGILL). Fix that at the hypervisor (Proxmox CPU type "host"), not here.
 # No version is hardcoded: take latest when it runs, otherwise the newest
 # release that passes a smoke test, so the add-on still builds on such hosts.
+# The package pulls a ~240MB platform-native binary via optional deps, so clean
+# the npm cache and temp dirs in the SAME layer - otherwise ~100MB+ of cache
+# gets baked into the image.
 COPY install-claude.sh /usr/local/bin/install-claude.sh
-RUN chmod +x /usr/local/bin/install-claude.sh && /usr/local/bin/install-claude.sh
+RUN chmod +x /usr/local/bin/install-claude.sh \
+    && /usr/local/bin/install-claude.sh \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /tmp/*
 
 # Install hass-mcp for Home Assistant integration and pymodbus for Modbus operations
 RUN pip3 install --no-cache-dir --break-system-packages hass-mcp pymodbus pyserial

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -139,6 +139,9 @@ RUN mkdir -p \
     /root/.config \
     /root/.local/bin
 
+# Add-on-managed CLAUDE.md (copied to the persistent dir at runtime)
+COPY CLAUDE.addon.md /usr/share/claudecode/CLAUDE.addon.md
+
 # Shell and tmux config.
 # These were heredocs (RUN cat > file << 'EOF'), which require BuildKit and a
 # `# syntax=docker/dockerfile:1.4` directive. Builders without heredoc support
@@ -168,64 +171,8 @@ CMD ["/bin/bash", "-c", "\
   export HA_URL=\"http://supervisor/core\" && \
   PERSIST_DIR=/homeassistant/.claudecode && \
   mkdir -p $PERSIST_DIR/config /root/.config && \
-  printf '%s\n' \
-    '# Claude Code - Home Assistant Add-on' \
-    '' \
-    '## Path Mapping' \
-    '' \
-    'In this add-on container, paths are mapped differently than HA Core:' \
-    '- \\`/homeassistant\\` = HA config directory (equivalent to \\`/config\\` in HA Core)' \
-    '- \\`/config\\` does NOT exist - always use \\`/homeassistant\\`' \
-    '' \
-    'When users mention \\`/config/...\\`, translate to \\`/homeassistant/...\\`' \
-    '' \
-    '## Available Paths' \
-    '' \
-    '| Path | Description | Access |' \
-    '|------|-------------|--------|' \
-    '| \\`/homeassistant\\` | HA configuration | read-write |' \
-    '| \\`/share\\` | Shared folder | read-write |' \
-    '| \\`/media\\` | Media files | read-write |' \
-    '| \\`/ssl\\` | SSL certificates | read-only |' \
-    '| \\`/backup\\` | Backups | read-only |' \
-    '' \
-    '## Home Assistant Integration' \
-    '' \
-    'Use the \\`homeassistant\\` MCP server to query entities and call services.' \
-    '' \
-    '## Reading Home Assistant Logs' \
-    '' \
-    '**Log levels (from most to least verbose):**' \
-    '- \\`debug\\` - Only shown if explicitly enabled in configuration.yaml' \
-    '- \\`info\\` - General information, shown by default' \
-    '- \\`warning\\` - Warnings, always shown' \
-    '- \\`error\\` - Errors, always shown' \
-    '' \
-    '**Commands to read logs:**' \
-    '\\`\\`\\`bash' \
-    '# View recent logs (ha CLI)' \
-    'ha core logs 2>&1 | tail -100' \
-    '' \
-    '# Filter by keyword' \
-    'ha core logs 2>&1 | grep -i keyword' \
-    '' \
-    '# Filter errors only' \
-    'ha core logs 2>&1 | grep -iE \"(error|exception)\"' \
-    '' \
-    '# Alternative: read log file directly' \
-    'tail -100 /homeassistant/home-assistant.log' \
-    '\\`\\`\\`' \
-    '' \
-    '**To enable debug logging for an integration**, add to \\`configuration.yaml\\`:' \
-    '\\`\\`\\`yaml' \
-    'logger:' \
-    '  default: info' \
-    '  logs:' \
-    '    custom_components.YOUR_INTEGRATION: debug' \
-    '\\`\\`\\`' \
-    '' \
-    '**Key insight:** \\`_LOGGER.debug()\\` calls are invisible unless the logger level is set to debug. Use \\`_LOGGER.info()\\` or \\`_LOGGER.warning()\\` for logs that should always appear.' \
-    > $PERSIST_DIR/CLAUDE.md && \
+  cp /usr/share/claudecode/CLAUDE.addon.md $PERSIST_DIR/CLAUDE.md && \
+  touch $PERSIST_DIR/CLAUDE.user.md && \
   if [ ! -L /root/.claude ]; then rm -rf /root/.claude; ln -s $PERSIST_DIR /root/.claude; fi && \
   if [ ! -L /root/.config/claude-code ]; then rm -rf /root/.config/claude-code; ln -s $PERSIST_DIR/config /root/.config/claude-code; fi && \
   if [ ! -L /root/.claude.json ]; then touch $PERSIST_DIR/.claude.json; rm -f /root/.claude.json; ln -s $PERSIST_DIR/.claude.json /root/.claude.json; fi && \

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -1,17 +1,13 @@
 ARG BUILD_FROM
 
-# Build a current ttyd web client. The client embedded in the ttyd 1.7.7
-# binary predates OSC 52 clipboard support (xterm.js 5.4, no clipboard addon),
-# so startup serves this one via --index instead. Built from a pinned ttyd
-# main commit with yarn (via corepack, fetched from the npm registry) so
-# yarn.lock is honored - a plain npm install resolves newer transitive deps
-# and fails type-checking. Everything is pinned (ttyd commit, corepack, and
-# the lockfile-resolved deps) so the output is reproducible and nothing
-# drifts between builds. COREPACK_INTEGRITY_KEYS=0 keeps a pinned corepack
-# working across npm signing-key rotations (which have broken pinned
-# corepacks before); transport is TLS and dependency integrity comes from
-# the yarn.lock checksums. Drop this stage and the --index flag once a ttyd
-# release newer than 1.7.7 ships and the download below is bumped.
+# Build a current ttyd web client: the one embedded in the ttyd 1.7.7 binary
+# predates OSC 52 clipboard support, so startup serves this build via --index.
+# Built with yarn so ttyd's lockfile is honored (npm resolves newer transitive
+# deps and fails type-checking). Everything is pinned - ttyd commit, corepack,
+# lockfile deps - so the output is reproducible. COREPACK_INTEGRITY_KEYS=0
+# keeps the pinned corepack working across npm signing-key rotations;
+# integrity comes from the yarn.lock checksums. Drop this stage and the
+# --index flag once a ttyd release newer than 1.7.7 ships.
 FROM ${BUILD_FROM} AS ttyd-client
 RUN apk add --no-cache curl nodejs npm
 ARG TTYD_CLIENT_COMMIT=2922cb89f518bae4d0fcf4d757a7419638fc71fc

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -1,4 +1,30 @@
 ARG BUILD_FROM
+
+# Build a current ttyd web client. The client embedded in the ttyd 1.7.7
+# binary predates OSC 52 clipboard support (xterm.js 5.4, no clipboard addon),
+# so startup serves this one via --index instead. Built from a pinned ttyd
+# main commit with yarn (via corepack, fetched from the npm registry) so
+# yarn.lock is honored - a plain npm install resolves newer transitive deps
+# and fails type-checking. Everything is pinned (ttyd commit, corepack, and
+# the lockfile-resolved deps) so the output is reproducible and nothing
+# drifts between builds. COREPACK_INTEGRITY_KEYS=0 keeps a pinned corepack
+# working across npm signing-key rotations (which have broken pinned
+# corepacks before); transport is TLS and dependency integrity comes from
+# the yarn.lock checksums. Drop this stage and the --index flag once a ttyd
+# release newer than 1.7.7 ships and the download below is bumped.
+FROM ${BUILD_FROM} AS ttyd-client
+RUN apk add --no-cache curl nodejs npm
+ARG TTYD_CLIENT_COMMIT=2922cb89f518bae4d0fcf4d757a7419638fc71fc
+RUN curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+        "https://github.com/tsl0922/ttyd/archive/${TTYD_CLIENT_COMMIT}.tar.gz" \
+        | tar xz && mv "ttyd-${TTYD_CLIENT_COMMIT}" /ttyd
+WORKDIR /ttyd/html
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+    COREPACK_NPM_REGISTRY=https://registry.npmjs.org \
+    COREPACK_INTEGRITY_KEYS=0
+RUN npm install -g corepack@0.35.0 && corepack enable && \
+    yarn install --immutable && yarn run inline
+
 FROM ${BUILD_FROM}
 
 # Labels
@@ -42,7 +68,8 @@ RUN apk add --no-cache \
     docker-cli \
     && update-ca-certificates
 
-# Install ttyd static binary (avoids libwebsockets issues)
+# Install ttyd static binary (avoids libwebsockets issues); the web client
+# it serves comes from the ttyd-client build stage above (see --index).
 ARG BUILD_ARCH
 RUN case "${BUILD_ARCH}" in \
         amd64) TTYD_ARCH="x86_64" ;; \
@@ -54,6 +81,7 @@ RUN case "${BUILD_ARCH}" in \
     curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
         "https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.${TTYD_ARCH}" -o /usr/bin/ttyd && \
     chmod +x /usr/bin/ttyd
+COPY --from=ttyd-client /ttyd/html/dist/inline.html /usr/share/ttyd/index.html
 
 # Install Claude Code.
 # 2.1.113 replaced the JS entrypoint with a Bun-compiled native binary, whose
@@ -295,6 +323,7 @@ CMD ["/bin/bash", "-c", "\
   if [ \"$REMOTE_CONTROL\" = \"true\" ]; then export CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX=\"$RC_SESSION_PREFIX\"; fi && \
   cd /homeassistant && \
   exec ttyd --port 7681 --writable --ping-interval 30 --max-clients 5 \
+    --index /usr/share/ttyd/index.html \
     -t fontSize=$FONT_SIZE \
     -t fontFamily=Monaco,Consolas,monospace \
     -t scrollback=20000 \

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -156,22 +156,24 @@ Since tmux captures mouse events, copy/paste works differently:
 
 | Action | How to do it |
 |--------|--------------|
+| **Copy (tmux copy-mode)** | Scroll up (enters copy-mode), select, then copy — lands directly on your clipboard¹ |
 | **Copy** | Hold `Ctrl+Shift` while selecting text with mouse |
 | **Paste** | `Shift+Insert` or middle-click |
 | **Alternative paste** | `Ctrl+Shift+V` (browser dependent) |
+
+¹ Clipboard integration (OSC 52) requires accessing Home Assistant over **HTTPS or localhost** — browsers block programmatic clipboard writes on plain HTTP. On plain HTTP, use the modifier-key gesture instead. A bonus of OSC 52: copy-mode copies wrapped lines as one logical line, so long URLs come out intact.
 
 **Note**: Regular right-click paste and simple mouse selection won't work because tmux intercepts these events for scrolling.
 
 #### Authenticating Claude Code (first launch)
 
-The authentication URL can be long and may wrap across multiple lines. To handle this:
+If you access Home Assistant over **HTTPS** (or localhost), the CLI's own **press `c` to copy** hint works — the login URL lands directly on your clipboard via OSC 52. Paste it into a new tab, authenticate, copy the auth code, and **paste** it back into the terminal with `Shift+Insert` or `Ctrl+Shift+V`.
 
-1. **Zoom out** your browser (`Ctrl + -` or `Cmd + -`) until the URL fits on a single line
-2. **Click the link** — it should open in a new tab
-3. Complete authentication in the browser and **copy the auth code**
-4. Click back on the terminal and **paste** with `Shift+Insert` or `Ctrl+Shift+V`
+On plain HTTP the browser blocks programmatic clipboard writes, so `c` won't work — but the terminal's link detection follows URLs across wrapped lines, so usually you can simply **click the URL** even when it spans several rows, or hold `Ctrl+Shift` and select it with the mouse — the selection is copied as one unbroken line.
 
-If clicking the link doesn't work, hold `Ctrl+Shift` while selecting the URL with your mouse to copy it, then paste it into your browser's address bar.
+If clicking or selecting only picks up part of the URL (this can happen when a full-screen UI redraws the screen row by row instead of letting text flow), **zoom out** your browser (`Ctrl + -` or `Cmd + -`) until the URL fits on a single line and click or select it there.
+
+Either way: complete authentication in the browser, **copy the auth code**, click back on the terminal, and **paste** it with `Shift+Insert` or `Ctrl+Shift+V`.
 
 ### Scrolling and Session Persistence Trade-offs
 
@@ -181,6 +183,7 @@ If clicking the link doesn't work, hold `Ctrl+Shift` while selecting the URL wit
 - ✅ Long-running Claude tasks continue in background
 - ✅ Mouse wheel scrolling works (enters copy mode automatically)
 - ✅ 20,000 line scrollback buffer
+- ✅ Copy-mode copies and `claude`'s "press `c` to copy" go straight to your clipboard (HTTPS/localhost only)
 - ⚠️ Use middle-click or Shift+Insert to paste (right-click paste may not work)
 
 **Without tmux (`session_persistence: false`):**

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -121,6 +121,10 @@ With `enable_remote_control`, sessions can be driven from `claude.ai/code` or th
 | `/ssl` | SSL certificates | read-only |
 | `/backup` | Backups | read-only |
 
+## Customizing Claude's Instructions
+
+The add-on regenerates `~/.claude/CLAUDE.md` (Claude Code's persistent instructions file) on every start, so don't edit it directly. Put your own instructions in `/homeassistant/.claudecode/CLAUDE.user.md` instead: the add-on creates it empty, never modifies it, and `CLAUDE.md` imports it — so anything you write there loads into every Claude Code session and survives restarts and add-on updates.
+
 ## Session Persistence
 
 When `session_persistence` is enabled, the add-on uses tmux to maintain your terminal session. This means:

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -161,19 +161,19 @@ Since tmux captures mouse events, copy/paste works differently:
 | **Paste** | `Shift+Insert` or middle-click |
 | **Alternative paste** | `Ctrl+Shift+V` (browser dependent) |
 
-¹ Clipboard integration (OSC 52) requires accessing Home Assistant over **HTTPS or localhost** — browsers block programmatic clipboard writes on plain HTTP. On plain HTTP, use the modifier-key gesture instead. A bonus of OSC 52: copy-mode copies wrapped lines as one logical line, so long URLs come out intact.
+¹ OSC 52 needs **HTTPS or localhost** — on plain HTTP, use the modifier-key gesture instead. Bonus: copy-mode copies wrapped lines as one logical line, so long URLs come out intact.
 
 **Note**: Regular right-click paste and simple mouse selection won't work because tmux intercepts these events for scrolling.
 
 #### Authenticating Claude Code (first launch)
 
-The simplest path works everywhere, including plain HTTP: **click the URL**. The login screen prints it as a real hyperlink (OSC 8), so even though it spans several rows, clicking *any* row opens the **complete** URL in a new tab after a confirmation dialog.
+**Click the URL** — this works everywhere, including plain HTTP. It's a real hyperlink (OSC 8): even though it wraps, any row opens the complete URL in a new tab after a confirmation prompt.
 
-If you access Home Assistant over **HTTPS** (or localhost), the CLI's own **press `c` to copy** hint also works — the login URL lands directly on your clipboard via OSC 52, ready to paste into a new tab. On plain HTTP the browser blocks programmatic clipboard writes, so `c` does nothing there — use the click.
+Over **HTTPS** (or localhost), the CLI's **press `c` to copy** hint also works via OSC 52. On plain HTTP browsers block clipboard writes — use the click.
 
-Avoid selecting the login URL with a `Ctrl+Shift`-drag: the login screen paints each row as a separate line, so the selection stitches the fragments together with line breaks. If you really need the URL as text, **zoom out** your browser (`Ctrl + -` or `Cmd + -`) until it fits on a single line first.
+Don't drag-select the URL: its rows are separate lines and copy with line breaks. If you need it as text, **zoom out** (`Ctrl + -` / `Cmd + -`) until it fits on one line.
 
-Either way: complete authentication in the browser, **copy the auth code**, click back on the terminal, and **paste** it with `Shift+Insert` or `Ctrl+Shift+V`.
+Then authenticate in the browser, copy the auth code, and paste it back with `Shift+Insert` or `Ctrl+Shift+V`.
 
 ### Scrolling and Session Persistence Trade-offs
 
@@ -184,7 +184,7 @@ Either way: complete authentication in the browser, **copy the auth code**, clic
 - ✅ Mouse wheel scrolling works (enters copy mode automatically)
 - ✅ 20,000 line scrollback buffer
 - ✅ Copy-mode copies and `claude`'s "press `c` to copy" go straight to your clipboard (HTTPS/localhost only)
-- ✅ Hyperlinks (OSC 8), like the wrapped `/login` URL, open complete with a single click
+- ✅ OSC 8 hyperlinks (e.g. the `/login` URL) open complete with one click
 - ⚠️ Use middle-click or Shift+Insert to paste (right-click paste may not work)
 
 **Without tmux (`session_persistence: false`):**

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -104,12 +104,40 @@ claude --continue
 | `auto_update_claude` | Auto-update Claude Code on startup (rolls back automatically if the new release cannot run) | true |
 | `enable_remote_control` | View and steer the session from claude.ai/code or the Claude mobile app. See the security note below | false |
 | `remote_control_session_prefix` | Prefix for auto-generated Remote Control session names | HomeAssistant |
+| `extra_npm_packages` | List of npm package specs to install at every container start under `/homeassistant/.claudecode/npm-global` (persistent across add-on rebuilds). Bin dir is on `PATH`. Use to add custom MCP servers without forking the Dockerfile. | `[]` |
 
 ### Remote Control
 
 With `enable_remote_control`, sessions can be driven from `claude.ai/code` or the Claude mobile app (requires a Pro, Max, Team, or Enterprise subscription; API keys are not supported).
 
 **Security note:** this add-on runs as root with full access to your Home Assistant host. Anyone who can sign in to the linked Claude account can control it. Leave this off unless you need it.
+
+### Custom MCP servers (`extra_npm_packages`)
+
+Add-on updates rebuild the container and wipe anything you `npm install -g` manually. `extra_npm_packages` re-installs a list of packages on every container start, to a persistent path on the HA volume.
+
+**Install:**
+
+1. Add packages to the option in the add-on Configuration tab:
+   ```yaml
+   extra_npm_packages:
+     - "@modelcontextprotocol/server-filesystem"
+     - "some-other-mcp@1.4.2"
+     - "@vendor/mcp"
+   ```
+2. Restart the add-on. Watch the log for `[INFO] Installing extra_npm_packages: ...`.
+3. Open a terminal in Claude Code and register the MCP server:
+   ```bash
+   claude mcp add-json filesystem '{"command":"mcp-server-filesystem","args":["/homeassistant"]}' -s user
+   ```
+   The binary lives at `/homeassistant/.claudecode/npm-global/bin/<bin-name>` and that directory is on `PATH`, so referencing it by name works.
+
+The MCP registration itself is persistent (stored in `~/.claude/settings.json`, which is symlinked to the HA volume), so step 3 is one-time.
+
+**Caveats:**
+- Re-installs on every container start; unpinned packages get the latest each time.
+- A bad package name logs `[WARN]` but doesn't stop the add-on.
+- Don't know the binary name? Run `ls /homeassistant/.claudecode/npm-global/bin/` after install.
 
 ## File Locations
 

--- a/claudecode/README.md
+++ b/claudecode/README.md
@@ -167,11 +167,11 @@ Since tmux captures mouse events, copy/paste works differently:
 
 #### Authenticating Claude Code (first launch)
 
-If you access Home Assistant over **HTTPS** (or localhost), the CLI's own **press `c` to copy** hint works — the login URL lands directly on your clipboard via OSC 52. Paste it into a new tab, authenticate, copy the auth code, and **paste** it back into the terminal with `Shift+Insert` or `Ctrl+Shift+V`.
+The simplest path works everywhere, including plain HTTP: **click the URL**. The login screen prints it as a real hyperlink (OSC 8), so even though it spans several rows, clicking *any* row opens the **complete** URL in a new tab after a confirmation dialog.
 
-On plain HTTP the browser blocks programmatic clipboard writes, so `c` won't work — but the terminal's link detection follows URLs across wrapped lines, so usually you can simply **click the URL** even when it spans several rows, or hold `Ctrl+Shift` and select it with the mouse — the selection is copied as one unbroken line.
+If you access Home Assistant over **HTTPS** (or localhost), the CLI's own **press `c` to copy** hint also works — the login URL lands directly on your clipboard via OSC 52, ready to paste into a new tab. On plain HTTP the browser blocks programmatic clipboard writes, so `c` does nothing there — use the click.
 
-If clicking or selecting only picks up part of the URL (this can happen when a full-screen UI redraws the screen row by row instead of letting text flow), **zoom out** your browser (`Ctrl + -` or `Cmd + -`) until the URL fits on a single line and click or select it there.
+Avoid selecting the login URL with a `Ctrl+Shift`-drag: the login screen paints each row as a separate line, so the selection stitches the fragments together with line breaks. If you really need the URL as text, **zoom out** your browser (`Ctrl + -` or `Cmd + -`) until it fits on a single line first.
 
 Either way: complete authentication in the browser, **copy the auth code**, click back on the terminal, and **paste** it with `Shift+Insert` or `Ctrl+Shift+V`.
 
@@ -184,6 +184,7 @@ Either way: complete authentication in the browser, **copy the auth code**, clic
 - ✅ Mouse wheel scrolling works (enters copy mode automatically)
 - ✅ 20,000 line scrollback buffer
 - ✅ Copy-mode copies and `claude`'s "press `c` to copy" go straight to your clipboard (HTTPS/localhost only)
+- ✅ Hyperlinks (OSC 8), like the wrapped `/login` URL, open complete with a single click
 - ⚠️ Use middle-click or Shift+Insert to paste (right-click paste may not work)
 
 **Without tmux (`session_persistence: false`):**

--- a/claudecode/apparmor.txt
+++ b/claudecode/apparmor.txt
@@ -72,4 +72,9 @@ profile claudecode flags=(attach_disconnected,mediate_deleted) {
 
   # Node.js modules
   /usr/lib/node_modules/** ixmr,
+
+  # Playwright MCP server (installed under /opt to avoid /usr/local/bin/mcp
+  # collision with hass-mcp; the /usr/local/bin/playwright-mcp symlink
+  # resolves through here, so AppArmor needs the /opt path allowed too)
+  /opt/playwright-mcp/** ixmr,
 }

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.67"
+version: "1.2.68"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.65"
+version: "1.2.66"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.66"
+version: "1.2.67"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.68"
+version: "1.2.69"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.69"
+version: "1.2.70"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:
@@ -42,6 +42,7 @@ options:
   auto_update_claude: true
   enable_remote_control: false
   remote_control_session_prefix: HomeAssistant
+  extra_npm_packages: []
 schema:
   enable_mcp: bool
   enable_playwright_mcp: bool
@@ -53,5 +54,7 @@ schema:
   auto_update_claude: bool
   enable_remote_control: bool
   remote_control_session_prefix: str
+  extra_npm_packages:
+    - str?
 environment:
   TERM: xterm-256color

--- a/claudecode/rootfs/root/.tmux.conf
+++ b/claudecode/rootfs/root/.tmux.conf
@@ -7,24 +7,17 @@ set -g mouse on
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 
-# OSC 52 clipboard integration with the browser terminal (needs the ttyd web
-# client served via --index; the browser only allows clipboard writes over
-# HTTPS or localhost). set-clipboard on lets both tmux copies (copy-mode,
-# set-buffer -w) and programs inside tmux (e.g. `claude`'s "press c to copy")
-# reach the system clipboard. The Ms override pins the selection to "c":
-# tmux fills %p1 with "" for its own copies and "c" for programs, and the
-# terminal's clipboard addon drops anything that isn't exactly "c" - so %p1
-# is printed with zero precision (i.e. not at all) and "c" is hardcoded.
+# OSC 52 clipboard for the browser terminal (needs the --index web client;
+# browsers allow clipboard writes over HTTPS/localhost only). set-clipboard on
+# forwards tmux copies and inner programs' OSC 52 (claude's "press c to copy").
+# The Ms override hardcodes the "c" selection - the only one the terminal's
+# clipboard addon accepts - and drops %p1 with zero precision.
 set -s set-clipboard on
 set -as terminal-overrides ',xterm*:Ms=\E]52;c%p1%.0s;%p2%s\007'
 
-# Forward OSC 8 hyperlinks to the browser terminal. Claude Code prints its
-# /login URL as an OSC 8 hyperlink: the URL is hard-wrapped into separate
-# rows on screen, but every row carries the complete URL as link metadata,
-# and xterm.js makes each row clickable (opens the full URL). tmux only
-# re-emits hyperlinks when the outer terminal declares support, and its
-# default xterm* feature list does not include it - declare it explicitly.
-# Needs tmux >= 3.4 (the base image ships 3.5a).
+# Pass OSC 8 hyperlinks through to the browser terminal - claude's /login URL
+# is one; every wrapped row carries the full URL, so any row is clickable.
+# tmux drops hyperlinks unless the outer terminal declares support (tmux >= 3.4).
 set -as terminal-features ',xterm*:hyperlinks'
 
 # User overrides, loaded last so they win. This file lives in the Home Assistant

--- a/claudecode/rootfs/root/.tmux.conf
+++ b/claudecode/rootfs/root/.tmux.conf
@@ -7,6 +7,17 @@ set -g mouse on
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 
+# OSC 52 clipboard integration with the browser terminal (needs the ttyd web
+# client served via --index; the browser only allows clipboard writes over
+# HTTPS or localhost). set-clipboard on lets both tmux copies (copy-mode,
+# set-buffer -w) and programs inside tmux (e.g. `claude`'s "press c to copy")
+# reach the system clipboard. The Ms override pins the selection to "c":
+# tmux fills %p1 with "" for its own copies and "c" for programs, and the
+# terminal's clipboard addon drops anything that isn't exactly "c" - so %p1
+# is printed with zero precision (i.e. not at all) and "c" is hardcoded.
+set -s set-clipboard on
+set -as terminal-overrides ',xterm*:Ms=\E]52;c%p1%.0s;%p2%s\007'
+
 # User overrides, loaded last so they win. This file lives in the Home Assistant
 # config directory, so it survives restarts, rebuilds and reinstalls - unlike
 # /root/.tmux.conf, which is part of the container image. -q ignores it when absent.

--- a/claudecode/rootfs/root/.tmux.conf
+++ b/claudecode/rootfs/root/.tmux.conf
@@ -18,6 +18,15 @@ bind -n WheelDownPane select-pane -t= \; send-keys -M
 set -s set-clipboard on
 set -as terminal-overrides ',xterm*:Ms=\E]52;c%p1%.0s;%p2%s\007'
 
+# Forward OSC 8 hyperlinks to the browser terminal. Claude Code prints its
+# /login URL as an OSC 8 hyperlink: the URL is hard-wrapped into separate
+# rows on screen, but every row carries the complete URL as link metadata,
+# and xterm.js makes each row clickable (opens the full URL). tmux only
+# re-emits hyperlinks when the outer terminal declares support, and its
+# default xterm* feature list does not include it - declare it explicitly.
+# Needs tmux >= 3.4 (the base image ships 3.5a).
+set -as terminal-features ',xterm*:hyperlinks'
+
 # User overrides, loaded last so they win. This file lives in the Home Assistant
 # config directory, so it survives restarts, rebuilds and reinstalls - unlike
 # /root/.tmux.conf, which is part of the container image. -q ignores it when absent.

--- a/claudecode/rootfs/usr/local/bin/playwright-mcp-launch
+++ b/claudecode/rootfs/usr/local/bin/playwright-mcp-launch
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Resolves the Playwright Browser hostname at MCP-spawn time. HA assigns
+# hostnames like <repo-id>-playwright-browser that we can't hardcode, and the
+# user may install Playwright Browser after Claude Code has already started.
+# PLAYWRIGHT_CDP_HOST env var (set from the playwright_cdp_host option) wins.
+# Otherwise ask Supervisor for any add-on whose slug contains "playwright-browser".
+HOST="$PLAYWRIGHT_CDP_HOST"
+if [ -z "$HOST" ]; then
+  # The /addons list endpoint exposes .slug but not .hostname — hostname only
+  # lives on /addons/{slug}/info. HA add-on hostnames are deterministic: the
+  # slug with underscores replaced by hyphens. Derive it locally so this works
+  # without needing per-add-on info access.
+  SLUG=$(curl -s -H "Authorization: Bearer $SUPERVISOR_TOKEN" http://supervisor/addons \
+    | jq -r '.data.addons[] | select(.slug | test("playwright-browser")) | .slug' \
+    | head -1)
+  [ -n "$SLUG" ] && HOST=$(echo "$SLUG" | tr '_' '-')
+fi
+if [ -z "$HOST" ] || [ "$HOST" = "null" ]; then
+  echo "[playwright-launch] Playwright Browser add-on not found via Supervisor API." >&2
+  echo "[playwright-launch] Install/start it, or set the playwright_cdp_host option." >&2
+  exit 1
+fi
+exec /usr/local/bin/playwright-mcp --cdp-endpoint "http://$HOST:9222" "$@"

--- a/claudecode/translations/en.yaml
+++ b/claudecode/translations/en.yaml
@@ -57,6 +57,13 @@ configuration:
       Prefix for auto-generated Remote Control session names visible in claude.ai/code
       and the Claude mobile app. Defaults to "HomeAssistant", producing names like
       "HomeAssistant-graceful-unicorn". Only applies when Enable Remote Control is on.
+  extra_npm_packages:
+    name: Extra npm Packages
+    description: >-
+      npm package specs (e.g. "@modelcontextprotocol/server-filesystem" or
+      "some-mcp@1.4.2") installed on every add-on start into a persistent
+      directory on the HA volume, so they survive add-on updates and rebuilds.
+      Use this to add custom MCP servers without forking the add-on.
 
 network:
   7681/tcp: Web Terminal (ttyd)

--- a/claudecode/translations/es.yaml
+++ b/claudecode/translations/es.yaml
@@ -60,6 +60,14 @@ configuration:
       Prefijo para los nombres de sesión de Control Remoto generados automáticamente,
       visible en claude.ai/code y la aplicación móvil de Claude. El valor predeterminado
       es "HomeAssistant", generando nombres como "HomeAssistant-graceful-unicorn". Solo aplica cuando el Control Remoto está habilitado.
+  extra_npm_packages:
+    name: Paquetes npm Adicionales
+    description: >-
+      Especificaciones de paquetes npm (p. ej. "@modelcontextprotocol/server-filesystem"
+      o "some-mcp@1.4.2") que se instalan en cada inicio del add-on en un directorio
+      persistente del volumen de HA, por lo que sobreviven a actualizaciones y
+      reconstrucciones del add-on. Úsalo para añadir servidores MCP personalizados
+      sin bifurcar el add-on.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/claudecode/translations/fr.yaml
+++ b/claudecode/translations/fr.yaml
@@ -48,6 +48,14 @@ configuration:
       Vérifiez et installez automatiquement les mises à jour de Claude Code au
       démarrage du module complémentaire. Garde Claude Code à jour sans nécessiter
       de changements de version du module complémentaire.
+  extra_npm_packages:
+    name: Paquets npm Supplémentaires
+    description: >-
+      Spécifications de paquets npm (p. ex. « @modelcontextprotocol/server-filesystem »
+      ou « some-mcp@1.4.2 ») installées à chaque démarrage du module complémentaire
+      dans un répertoire persistant du volume HA ; elles survivent donc aux mises à
+      jour et reconstructions du module complémentaire. Utilisez cette option pour
+      ajouter des serveurs MCP personnalisés sans forker le module complémentaire.
 
 network:
   7681/tcp: Terminal Web (ttyd)

--- a/claudecode/translations/pt-BR.yaml
+++ b/claudecode/translations/pt-BR.yaml
@@ -60,6 +60,14 @@ configuration:
       Prefixo para nomes de sessão de Controle Remoto gerados automaticamente, visível
       no claude.ai/code e no aplicativo móvel do Claude. O padrão é "HomeAssistant",
       gerando nomes como "HomeAssistant-graceful-unicorn". Aplicável apenas quando o Controle Remoto está habilitado.
+  extra_npm_packages:
+    name: Pacotes npm Adicionais
+    description: >-
+      Especificações de pacotes npm (ex.: "@modelcontextprotocol/server-filesystem"
+      ou "some-mcp@1.4.2") instaladas em cada inicialização do add-on em um diretório
+      persistente no volume do HA, sobrevivendo a atualizações e reconstruções do
+      add-on. Use para adicionar servidores MCP personalizados sem fazer fork do
+      add-on.
 
 network:
   7681/tcp: Terminal Web (ttyd)


### PR DESCRIPTION
Note: Stacked on #39 — please merge that first. Until it merges, this diff also shows the parent PRs' commits; this PR's own change is the last commit (v1.2.70). Versions are sequential across the stack so there are no conflicts on config.yaml or the changelog.

Add-on updates rebuild the container and wipe anything installed with a manual npm install -g. The new extra_npm_packages option re-installs a list of npm package specs on every container start into /homeassistant/.claudecode/npm-global on the persistent HA volume, and that prefix's bin directory is on PATH - so custom MCP servers survive add-on updates without forking the Dockerfile.

A failed install logs a [WARN] but never blocks startup.