### PR TITLE
Add poppler-utils to claudecode image for PDF support

### DIFF
--- a/claudecode/CHANGELOG.md
+++ b/claudecode/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.65-poppler1] - 2026-09-08
+
+### Fixed
+- Claude Code's `Read` tool cannot render PDF pages: `pdftoppm` (from `poppler-utils`) is not installed in the image, so any PDF read fails with "pdftoppm is not installed". The package cannot be installed at runtime either — `apk` returns `Permission denied` on exec even as root. Added `poppler-utils` to the build-time `apk add` list (see robsonfelix/robsonfelix-hass-addons#45)
+
 ## [1.2.65] - 2026-07-08
 
 ### Security

--- a/claudecode/Dockerfile
+++ b/claudecode/Dockerfile
@@ -38,6 +38,7 @@ RUN apk add --no-cache \
     openssl \
     ripgrep \
     p7zip \
+    poppler-utils \
     socat \
     docker-cli \
     && update-ca-certificates

--- a/claudecode/config.yaml
+++ b/claudecode/config.yaml
@@ -1,6 +1,6 @@
 name: Claude Code
 description: Run Claude Code AI assistant inside Home Assistant to create automations, debug issues, and manage your smart home configuration
-version: "1.2.65"
+version: "1.2.65-poppler1"
 slug: claudecode
 url: https://github.com/robsonfelix/robsonfelix-hass-addons
 arch:


### PR DESCRIPTION
## Summary
- Claude Code's `Read` tool renders PDF pages via `pdftoppm` (from `poppler-utils`), which isn't installed in the `claudecode` image, so reading any PDF fails with `pdftoppm is not installed`.
- The package can't be added at runtime either: `apk` returns `Permission denied` on exec even as root, so it has to be baked in at build time.
- Adds `poppler-utils` to the existing `apk add` block in `claudecode/Dockerfile`, bumps the add-on version, and adds a changelog entry.

Fixes #45

## Test plan
- [ ] Build the `claudecode` image with this change
- [ ] Confirm `pdftoppm -v` runs inside the container
- [ ] Confirm Claude Code's `Read` tool can read a multi-page PDF (e.g. under `/share`) without the "pdftoppm is not installed" error